### PR TITLE
Errant APC and Camera Removal

### DIFF
--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -46906,13 +46906,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
-"jyE" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/wall/r_wall,
-/area/engineering/engine_gas)
 "jyV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -49025,11 +49018,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/foyer)
-"mOA" = (
-/obj/effect/floor_decal/corner/yellow/border,
-/obj/machinery/camera/autoname,
-/turf/simulated/floor/tiled/dark,
-/area/engineering/aft_hallway)
 "mOU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51043,13 +51031,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
-"pYJ" = (
-/obj/machinery/camera/network/engine{
-	c_tag = "ENG - Core Aft Starboard";
-	dir = 8
-	},
-/turf/simulated/wall/r_wall,
-/area/engineering/aft_hallway)
 "qaS" = (
 /obj/item/weapon/storage/firstaid/surgery,
 /obj/structure/table/standard,
@@ -85860,7 +85841,7 @@ fhF
 fhF
 dic
 fhF
-jyE
+fhF
 fhF
 bvT
 qjL
@@ -86374,7 +86355,7 @@ fpB
 uUW
 jdk
 wox
-mOA
+bDI
 shh
 bvT
 qjL
@@ -86889,7 +86870,7 @@ och
 mHf
 bDq
 bDO
-pYJ
+shh
 bvT
 qjL
 aaa


### PR DESCRIPTION
Ha ha Map bugs.
Removes Errant Cameras and APCs from Engineering Hallway and Gas Storage.