### PR TITLE
Makes ARES Couch all black.

### DIFF
--- a/maps/Arfs/residential/residential_arf.dmm
+++ b/maps/Arfs/residential/residential_arf.dmm
@@ -28764,7 +28764,7 @@
 /area/residential/room12)
 "iBK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/bed/chair/sofa/corner{
+/obj/structure/bed/chair/sofa/black/corner{
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
@@ -30455,7 +30455,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/bed/chair/sofa/corner{
+/obj/structure/bed/chair/sofa/black/corner{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,

--- a/maps/Arfs/residential/residential_arf.dmm
+++ b/maps/Arfs/residential/residential_arf.dmm
@@ -35191,7 +35191,7 @@
 	},
 /obj/machinery/door/airlock/ckey{
 	icon = 'icons/obj/doors/vault.dmi';
-	req_one_ckey = list("phantomwolfZero","thingpony")
+	req_one_ckey = list("phantomwolfzero","thingpony")
 	},
 /turf/simulated/floor/tiled,
 /area/residential/room14)


### PR DESCRIPTION
Really should be a way to see all map icon types.
@thingpony 