### PR TITLE
Sensor and Knot replacement.

### DIFF
--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -12624,14 +12624,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Cargo/Civilian Subgrid";
-	name_tag = "Cargo/Civilian Subgrid"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian_east)
 "aAa" = (
@@ -12761,6 +12753,11 @@
 	c_tag = "ENGI - Civilian Substation";
 	dir = 8
 	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Cargo/Civilian Subgrid";
+	name_tag = "Cargo/Civilian Subgrid"
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian_east)
 "aAo" = (
@@ -42012,6 +42009,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
+"dLC" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Engine Output";
+	name_tag = "Engine Output"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "dMi" = (
 /obj/structure/bed/padded,
 /obj/effect/floor_decal/corner/paleblue{
@@ -50254,10 +50267,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Engine Output";
-	name_tag = "Engine Output"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "pdI" = (
@@ -89230,7 +89239,7 @@ mez
 bEy
 xQl
 vjU
-wMj
+dLC
 gXF
 fMs
 fMs


### PR DESCRIPTION
Actually puts a knot under the Engine Output Powernet Sensor
Moves the Civilian Sensor off the red wire and moves the knot.