### PR TITLE
Misc Fixes to Deck 2

### DIFF
--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -48298,11 +48298,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "msL" = (
-/obj/machinery/shield_gen,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/shield_gen/external,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "mtx" = (
@@ -52355,7 +52355,6 @@
 	name = "Canister Storage";
 	req_access = list(11)
 	},
-/obj/structure/sign/department/engine,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_gas)
 "rHn" = (
@@ -56078,7 +56077,7 @@
 /area/hallway/primary/central_two)
 "wQa" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/shield_gen/external,
+/obj/machinery/shieldwallgen,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "wQk" = (
@@ -96537,7 +96536,7 @@ bvy
 sWm
 sWm
 sWm
-hjc
+sWm
 aaa
 aaa
 aaa
@@ -97052,7 +97051,7 @@ sWm
 sWm
 sWm
 sWm
-sWm
+hjc
 aaa
 aaa
 aaa


### PR DESCRIPTION
Removes errant sign in Engineering Gas Storage.
Removes a Bubble Shield generator for a Hull Shield generator.
Moves a Diffuser near Atmos Airlock to a better position.