### PR TITLE
Update arfs-3-deckthree.dmm

### DIFF
--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -4115,6 +4115,7 @@
 /obj/machinery/requests_console{
 	pixel_y = 30
 	},
+/obj/structure/bookcase/bookcart,
 /turf/simulated/floor/wood,
 /area/library)
 "if" = (
@@ -7254,6 +7255,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/gear)
+"pk" = (
+/obj/effect/floor_decal/chapel{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "pl" = (
 /turf/simulated/wall,
 /area/chapel/office)
@@ -7753,8 +7764,12 @@
 	tag = "icon-corner_kafel (NORTHEAST)"
 	},
 /obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/rig/ert/medical,
-/obj/item/weapon/rig/ert/medical,
+/obj/item/weapon/rig/ert/medical{
+	req_access = list()
+	},
+/obj/item/weapon/rig/ert/medical{
+	req_access = list()
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/cmostore)
 "qt" = (
@@ -8378,6 +8393,12 @@
 	})
 "rL" = (
 /obj/machinery/camera/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "rM" = (
@@ -9778,6 +9799,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
+"uZ" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 9
+	},
+/obj/item/device/radio/intercom{
+	canhear_range = 5;
+	dir = 8;
+	frequency = 1487;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "va" = (
 /obj/structure/closet/crate,
 /obj/random/explorer_shield,
@@ -10169,6 +10204,19 @@
 /obj/structure/flora/pottedplant/unusual,
 /turf/simulated/floor/wood,
 /area/chapel/office)
+"wa" = (
+/obj/effect/floor_decal/chapel{
+	dir = 8;
+	tag = "icon-chapel (WEST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "wb" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -11288,6 +11336,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/wedding_chapel_changing_room)
+"yu" = (
+/obj/item/device/radio/intercom{
+	canhear_range = 5;
+	dir = 8;
+	frequency = 1487;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -21
+	},
+/turf/simulated/floor/wood,
+/area/exploration/waiting_room)
 "yv" = (
 /obj/machinery/power/port_gen/pacman/mrs,
 /obj/structure/cable/green{
@@ -12371,6 +12430,12 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/rnd/rdoffice)
+"AT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "AU" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin{
@@ -12423,6 +12488,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/server)
+"AY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "AZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light_switch{
@@ -14040,6 +14114,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
+"Ev" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "Ew" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14441,8 +14521,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -15424,17 +15504,6 @@
 /obj/machinery/gear_painter,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/wedding_chapel_changing_room)
-"HL" = (
-/obj/item/device/radio/intercom{
-	canhear_range = 5;
-	dir = 8;
-	frequency = 1487;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -21
-	},
-/turf/simulated/floor/wood,
-/area/exploration/waiting_room)
 "HM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash_pile,
@@ -15795,20 +15864,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
-"IP" = (
-/obj/effect/floor_decal/corner_oldtile/purple{
-	dir = 9
-	},
-/obj/item/device/radio/intercom{
-	canhear_range = 5;
-	dir = 8;
-	frequency = 1487;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/exploration/hallway)
 "IQ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -15887,8 +15942,12 @@
 	tag = "icon-corner_kafel (NORTHEAST)"
 	},
 /obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/rig/ert/medical,
-/obj/item/weapon/rig/ert/medical,
+/obj/item/weapon/rig/ert/medical{
+	req_access = list()
+	},
+/obj/item/weapon/rig/ert/medical{
+	req_access = list()
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/cmostore)
 "IY" = (
@@ -19570,6 +19629,12 @@
 "QV" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "QW" = (
@@ -19681,6 +19746,9 @@
 "Rj" = (
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -20123,8 +20191,11 @@
 /area/crew_quarters/medbreak)
 "Sl" = (
 /obj/effect/floor_decal/chapel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -20363,6 +20434,9 @@
 /area/maintenance/security_starboard)
 "SQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -42911,7 +42985,7 @@ ph
 ph
 ph
 ph
-aa
+ph
 aa
 aa
 aa
@@ -43167,8 +43241,8 @@ mt
 wY
 wS
 Rj
+Ev
 ph
-aa
 aa
 aa
 aa
@@ -43424,8 +43498,8 @@ ph
 Jn
 ph
 rL
+AT
 ph
-aa
 aa
 aa
 aa
@@ -43680,7 +43754,7 @@ aa
 mt
 uX
 nd
-RF
+AY
 ph
 pp
 pp
@@ -44194,12 +44268,12 @@ aa
 pp
 uC
 DR
-NW
+wa
 Ak
 NW
 DR
 Rr
-DR
+pk
 TC
 mt
 aa
@@ -56569,7 +56643,7 @@ pJ
 ur
 LJ
 oz
-HL
+yu
 lP
 Qw
 NB
@@ -57854,7 +57928,7 @@ kQ
 wU
 LJ
 JY
-IP
+uZ
 LT
 Wn
 HY

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -6946,6 +6946,9 @@
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/water_cooler/full,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood,
 /area/exploration/waiting_room)
 "oA" = (
@@ -9081,6 +9084,10 @@
 /obj/structure/table/bench/sifwooden/padded,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
 	},
 /turf/simulated/floor/wood,
 /area/exploration/waiting_room)
@@ -15417,6 +15424,17 @@
 /obj/machinery/gear_painter,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/wedding_chapel_changing_room)
+"HL" = (
+/obj/item/device/radio/intercom{
+	canhear_range = 5;
+	dir = 8;
+	frequency = 1487;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -21
+	},
+/turf/simulated/floor/wood,
+/area/exploration/waiting_room)
 "HM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash_pile,
@@ -15777,6 +15795,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
+"IP" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 9
+	},
+/obj/item/device/radio/intercom{
+	canhear_range = 5;
+	dir = 8;
+	frequency = 1487;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "IQ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -56537,7 +56569,7 @@ pJ
 ur
 LJ
 oz
-NT
+HL
 lP
 Qw
 NB
@@ -57822,7 +57854,7 @@ kQ
 wU
 LJ
 JY
-Wn
+IP
 LT
 Wn
 HY


### PR DESCRIPTION
Adds a missing air alarm, intercom, and newscaster to exploration waiting room