### PR TITLE
Residential Jobs

### DIFF
--- a/content_arfs/code/datums/outfits/jobs_arfs.dm
+++ b/content_arfs/code/datums/outfits/jobs_arfs.dm
@@ -6,3 +6,12 @@
 	id_type = /obj/item/weapon/card/id/blueshield
 	pda_type = /obj/item/device/pda/captain
 	r_hand = /obj/item/weapon/clipboard
+
+/decl/hierarchy/outfit/job/resident
+	name = OUTFIT_JOB_NAME("Resident")
+	uniform = /obj/item/clothing/under/color/grey
+	id_type = /obj/item/weapon/card/id/generic
+	backpack = /obj/item/weapon/storage/backpack
+	l_ear = /obj/item/device/radio/headset
+	shoes = /obj/item/clothing/shoes/laceup
+	pda_type = /obj/item/device/pda

--- a/content_arfs/overrides/jobs/assistant.dm
+++ b/content_arfs/overrides/jobs/assistant.dm
@@ -1,13 +1,14 @@
 /datum/job/assistant
     alt_titles = list(
-    	"Tourist",
-    	"Businessman",
-    	"Trader",
     	"Assistant",
     	"Technical Assistant",
     	"Medical Intern",
     	"Research Assistant",
-    	"Passenger",
+    	"Passenger")
+	/*
+		"Tourist",
+    	"Businessman",
+    	"Trader",
 		"Entertainer",
 		"Lifeguard",
 		"Waiter",
@@ -43,4 +44,4 @@
 		"Nanotrasen Peace Officer",
 		"Prisoner",
 		"Belly Filler",
-		"Resident")
+		"Resident") */

--- a/content_arfs/overrides/jobs/jobs.dm
+++ b/content_arfs/overrides/jobs/jobs.dm
@@ -1,0 +1,1 @@
+var/const/RESIDENTIAL		=(1<<15)

--- a/content_arfs/overrides/jobs/residential.dm
+++ b/content_arfs/overrides/jobs/residential.dm
@@ -1,0 +1,59 @@
+datum/job/residential
+	title = "Resident"
+	flag = RESIDENTIAL
+	departments = list(DEPARTMENT_CIVILIAN)
+	department_flag = RESIDENTIAL
+	faction = "Station"
+	total_positions = -1
+	spawn_positions = -1
+	supervisors = "any present Central Command Staff."
+	selection_color = "#FFFFFF" //White for all the spunk ~TK
+	access = list()			// Took access from assistant, need to check to make sure it works properly ~TK
+	minimal_access = list()	//
+
+	outfit_type = /decl/hierarchy/outfit/job/resident
+	job_description = "A person living on the Residential Station Serenity."
+	alt_titles = list(
+    	"Tourist",
+    	"Businessman",
+    	"Trader",
+    	"Assistant",
+		"Entertainer",
+		"Lifeguard",
+		"Waiter",
+		"Waitress",
+		"Secretary",
+		"Delivery Staff",
+		"Holo-Gladiator",
+		"Musician",
+		"Busker",
+		"Rock Star",
+		"Country Star",
+		"Rap Star",
+		"Pop Idol",
+		"Jazz Artist",
+		"Painter",
+		"Maintenance Explorer",
+		"Masseuse","Massager",
+		"Test Subject",
+		"Fisher",
+		"Vidcam Model",
+		"Escort",
+		"Actor",
+		"Actress",
+		"Professional Cuddle Artist",
+		"Pet",
+		"Laser Tag Warrior",
+		"Stripper",
+		"Exotic Dancer",
+		"Belly Dancer",
+		"Fashion Model",
+		"Live Performer",
+		"Slacker",
+		"Nanotrasen Peace Officer",,
+		"Belly Filler",
+		"Resident",
+		"Off Duty Captain",
+		"Serenity Engineer",
+		"Serenity Med Staff",
+		"Serenity Security") //List can be extended at a later date, this is just a starting point for future roleplay focused off-Dallus jobs. ~TK

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3970,6 +3970,8 @@
 #include "content_arfs\overrides\jobs\detective.dm"
 #include "content_arfs\overrides\jobs\doctor.dm"
 #include "content_arfs\overrides\jobs\iaa.dm"
+#include "content_arfs\overrides\jobs\jobs.dm"
+#include "content_arfs\overrides\jobs\residential.dm"
 #include "content_arfs\overrides\jobs\security.dm"
 #include "content_arfs\overrides\jobs\service.dm"
 #include "content_arfs\overrides\jobs\supply.dm"


### PR DESCRIPTION
These add the separated residential jobs, taking most of them away from the on-ship assistant job alt-titles for Serenity RP purposes.