### PR TITLE
Adding Residentials Department

### DIFF
--- a/content_arfs/overrides/jobs/event_dynamic_arfs.dm
+++ b/content_arfs/overrides/jobs/event_dynamic_arfs.dm
@@ -1,0 +1,56 @@
+/proc/number_active_with_role()
+	var/list/active_with_role = list()
+	active_with_role["Engineer"] = 0
+	active_with_role["Medical"] = 0
+	active_with_role["Security"] = 0
+	active_with_role["Scientist"] = 0
+	active_with_role["AI"] = 0
+	active_with_role["Cyborg"] = 0
+	active_with_role["Janitor"] = 0
+	active_with_role["Gardener"] = 0
+
+
+
+		active_with_role["Any"]++
+
+		if(istype(M, /mob/living/silicon/robot))
+			var/mob/living/silicon/robot/R = M
+			if(R.module)
+				if(istype(R.module, /obj/item/weapon/robot_module/robot/engineering))
+					active_with_role["Engineer"]++
+				else if(istype(R.module, /obj/item/weapon/robot_module/robot/security))
+					active_with_role["Security"]++
+				else if(istype(R.module, /obj/item/weapon/robot_module/robot/medical))
+					active_with_role["Medical"]++
+				else if(istype(R.module, /obj/item/weapon/robot_module/robot/research))
+					active_with_role["Scientist"]++
+
+		if(M.mind.assigned_role in SSjob.get_job_titles_in_department(DEPARTMENT_ENGINEERING))
+			active_with_role["Engineer"]++
+
+		if(M.mind.assigned_role in SSjob.get_job_titles_in_department(DEPARTMENT_MEDICAL))
+			active_with_role["Medical"]++
+
+		if(M.mind.assigned_role in SSjob.get_job_titles_in_department(DEPARTMENT_SECURITY))
+			active_with_role["Security"]++
+
+		if(M.mind.assigned_role in SSjob.get_job_titles_in_department(DEPARTMENT_RESEARCH))
+			active_with_role["Scientist"]++
+
+		if(M.mind.assigned_role == "AI")
+			active_with_role["AI"]++
+
+		if(M.mind.assigned_role == "Cyborg")
+			active_with_role["Cyborg"]++
+
+     var/datum/job/janitor/JJ
+        if((M.mind.assigned_role == JJ.title) || (M.mind.assigned_role in JJ.alt_titles))
+            active_with_role["Janitor"]++
+
+        var/datum/job/hydro/HJ
+        if((M.mind.assigned_role == HJ.title) || (M.mind.assigned_role in HJ.alt_titles))
+            active_with_role["Gardener"]++
+
+	return active_with_role
+
+//add jobs that should effect weight

--- a/content_arfs/overrides/jobs/jobs.dm
+++ b/content_arfs/overrides/jobs/jobs.dm
@@ -1,1 +1,7 @@
 var/const/RESIDENTIAL		=(1<<15)
+
+/datum/department/residential
+	name = DEPARTMENT_RESIDENTIAL
+	short_name = "Residents"
+	color = "#FFFFFF"
+	sorting_order = -2 //stinky cummies ~TK

--- a/content_arfs/overrides/jobs/residential.dm
+++ b/content_arfs/overrides/jobs/residential.dm
@@ -1,7 +1,7 @@
 datum/job/residential
 	title = "Resident"
 	flag = RESIDENTIAL
-	departments = list(DEPARTMENT_CIVILIAN)
+	departments = list(DEPARTMENT_RESIDENTIAL)
 	department_flag = RESIDENTIAL
 	faction = "Station"
 	total_positions = -1


### PR DESCRIPTION
Preliminary process for squeezing more functionality and flexibility out of the event manager system to allow more jobs to interact with event weight.  I'm getting two errors on content_arfs\overrides\jobs\jobs.dm and content_arfs\overrides\jobs\jobs.dm.  Both errors are line for saying that DEPARTMENT_RESIDENTIAL is an undefined var.