### PR TITLE
Dallus Dock and Space Orbit Things

### DIFF
--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -18201,6 +18201,9 @@
 	dir = 8;
 	pixel_x = -26
 	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/longue_area)
 "aKY" = (
@@ -18256,6 +18259,11 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 9;
+	icon_state = "corner_oldtile";
+	tag = "icon-corner_oldtile (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fore)
@@ -18702,6 +18710,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 9;
+	icon_state = "corner_oldtile";
+	tag = "icon-corner_oldtile (NORTHWEST)"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fore)
 "aLR" = (
@@ -19146,6 +19159,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 5;
+	icon_state = "corner_oldtile";
+	tag = "icon-corner_oldtile (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
@@ -43513,6 +43531,19 @@
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/longue_area)
+"ggY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 5;
+	icon_state = "corner_oldtile";
+	tag = "icon-corner_oldtile (NORTHEAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_two)
 "ghI" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -91205,7 +91236,7 @@ dzF
 aKX
 aLu
 ggo
-aUj
+ggY
 aNd
 aQd
 aQC
@@ -91462,7 +91493,7 @@ cfw
 aKW
 aKx
 eRW
-aUj
+ggY
 aNd
 bxz
 aQD

--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -17733,18 +17733,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fore)
 "aJY" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass{
-	name = "Departures"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/stairs/spawner/north,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/central_one)
 "aJZ" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6;
@@ -18019,36 +18010,28 @@
 /turf/simulated/wall,
 /area/quartermaster/miningdock)
 "aKw" = (
-/turf/simulated/wall/wood,
-/area/crew_quarters/sleep/bedrooms)
-"aKx" = (
-/obj/item/weapon/bedsheet/brown,
-/obj/structure/bed/padded,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
-"aKy" = (
-/obj/item/weapon/bedsheet/brown,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/bed/padded,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
-"aKz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/grey{
-	dir = 9;
-	tag = "icon-corner_white (NORTHWEST)"
+	dir = 6;
+	icon_state = "corner_oldtile";
+	tag = "icon-corner_oldtile (SOUTHEAST)"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/central_one)
+"aKx" = (
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
+"aKy" = (
+/turf/simulated/wall/wood,
+/area/hallway/primary/central_one)
+"aKz" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "aKB" = (
 /obj/random/maintenance/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -18194,79 +18177,87 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
 "aKU" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "SSD Bunk"
+/obj/structure/stairs/spawner/north,
+/obj/effect/floor_decal/corner/grey{
+	dir = 6;
+	icon_state = "corner_oldtile";
+	tag = "icon-corner_oldtile (SOUTHEAST)"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
 "aKV" = (
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
+/obj/effect/floor_decal/corner/grey{
+	dir = 9;
+	tag = "icon-corner_white (NORTHWEST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
 "aKW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
+"aKX" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/bed/chair/sofa{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
+"aKY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
-"aKX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
-"aKY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "aKZ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "SSD Bunk"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "aLa" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 9;
-	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -18475,33 +18466,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fore)
 "aLs" = (
-/obj/item/weapon/bedsheet/brown,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/structure/bed/padded,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
 "aLt" = (
-/obj/item/weapon/bedsheet/brown,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/floor_decal/corner/grey{
+	dir = 6;
+	icon_state = "corner_oldtile";
+	tag = "icon-corner_oldtile (SOUTHEAST)"
 	},
-/obj/structure/bed/padded,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
+/obj/structure/sign/deck/second{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
 "aLu" = (
-/obj/item/weapon/bedsheet/brown,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -32
+/obj/structure/bed/chair/sofa/right{
+	dir = 4
 	},
-/obj/structure/cable/green,
-/obj/structure/bed/padded,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/bedrooms)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "aLv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18730,16 +18713,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fore)
 "aLQ" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass{
-	name = "Departures"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fore)
@@ -18753,15 +18732,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "aLS" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass{
-	name = "Departures"
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fore)
+/area/hallway/primary/central_two)
 "aLT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -19100,54 +19078,49 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_one)
-"aMv" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 5;
-	icon_state = "corner_oldtile";
-	tag = "icon-corner_oldtile (NORTHEAST)"
-	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
+"aMv" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 1;
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_one)
 "aMw" = (
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
 /obj/effect/floor_decal/corner/grey{
-	dir = 5;
-	icon_state = "corner_oldtile";
-	tag = "icon-corner_oldtile (NORTHEAST)"
+	dir = 6;
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_one)
+/area/hallway/primary/fore)
 "aMx" = (
-/obj/machinery/atm{
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 5;
-	icon_state = "corner_oldtile";
-	tag = "icon-corner_oldtile (NORTHEAST)"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 4;
+	tag = "icon-corner_white (EAST)"
+	},
+/obj/structure/sign/directions/stairs_up{
+	pixel_x = 32;
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_one)
@@ -19182,54 +19155,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "aMA" = (
-/obj/structure/sign/department/dock{
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 5;
-	icon_state = "corner_oldtile";
-	tag = "icon-corner_oldtile (NORTHEAST)"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
+/area/hallway/primary/central_one)
 "aMB" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 5;
-	icon_state = "corner_oldtile";
-	tag = "icon-corner_oldtile (NORTHEAST)"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/requests_console{
-	pixel_y = 30
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "aMC" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/window{
+	dir = 2;
+	name = "Lounge"
 	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 5;
-	icon_state = "corner_oldtile";
-	tag = "icon-corner_oldtile (NORTHEAST)"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "aMD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -21083,6 +21027,10 @@
 	icon_state = "corner_oldtile";
 	tag = "icon-corner_oldtile (SOUTHWEST)"
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_one)
 "aQb" = (
@@ -21111,6 +21059,7 @@
 	icon_state = "corner_oldtile";
 	tag = "icon-corner_oldtile (SOUTHWEST)"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_one)
 "aQc" = (
@@ -40756,6 +40705,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering)
+"cfw" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/structure/bed/chair/sofa,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "cgp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -41675,6 +41631,25 @@
 /obj/item/weapon/storage/toolbox/emergency,
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/residential)
+"dzF" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/structure/bed/chair/sofa/corner{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -27;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "dAz" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
@@ -42529,6 +42504,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/break_room)
+"eRW" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "eSp" = (
 /obj/effect/floor_decal/borderfloor/shifted{
 	dir = 4
@@ -42846,6 +42825,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering)
+"fkT" = (
+/obj/structure/bed/chair/sofa/left,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "fma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -43539,6 +43523,13 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/security/brig)
+"ggo" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/woodentable,
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "ghI" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -46293,6 +46284,17 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_gas)
+"jFv" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9;
+	tag = "icon-corner_white (NORTHWEST)"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#edb02d"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
 "jFx" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -47387,6 +47389,14 @@
 	},
 /turf/simulated/wall,
 /area/medical/virology)
+"lnF" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9;
+	tag = "icon-corner_white (NORTHWEST)"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
 "loF" = (
 /obj/machinery/atmospherics/pipe/tank/phoron{
 	dir = 8
@@ -52669,6 +52679,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/security_cell_hallway)
+"sca" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6;
+	tag = "icon-corner_white (SOUTHEAST)"
+	},
+/obj/machinery/atm{
+	pixel_x = 27
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/fore)
 "scr" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -53548,6 +53568,12 @@
 	},
 /turf/space,
 /area/space)
+"tnK" = (
+/obj/machinery/door/window{
+	name = "Lounge"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "tqj" = (
 /obj/machinery/door/blast/regular{
 	id = "SupermatterPort";
@@ -54263,6 +54289,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/eva)
+"ugW" = (
+/obj/structure/stairs/spawner/north,
+/obj/effect/floor_decal/corner/grey{
+	dir = 9;
+	tag = "icon-corner_white (NORTHWEST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
 "uhW" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil{
@@ -55013,6 +55047,16 @@
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/tiled/dark,
 /area/engineering)
+"vcQ" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green,
+/obj/item/weapon/material/ashtray/glass,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/longue_area)
 "vdR" = (
 /obj/structure/shuttle/window,
 /obj/structure/grille,
@@ -56056,6 +56100,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_eva)
+"wKE" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6;
+	icon_state = "corner_oldtile";
+	tag = "icon-corner_oldtile (SOUTHEAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
 "wLm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -56100,6 +56152,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"wNg" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_two)
 "wNh" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -89640,7 +89701,7 @@ atH
 bCc
 auT
 aua
-aus
+sca
 aye
 aLP
 aMt
@@ -89896,10 +89957,10 @@ aHM
 aHM
 aHM
 aHM
-aKw
-aKU
-aKw
-aKw
+aKy
+aKy
+aKy
+aKy
 aMu
 aMX
 aPZ
@@ -90153,10 +90214,10 @@ bCQ
 bIy
 bzk
 aHM
-aKx
+ugW
 aKV
-aKx
-aKw
+jFv
+lnF
 aMv
 aMX
 buh
@@ -90410,11 +90471,11 @@ bge
 aIM
 aIM
 aHM
-aKx
-aKV
+aJY
 aLs
-aKw
-aMw
+aLs
+aMA
+aMr
 aMX
 aQb
 aQz
@@ -90667,9 +90728,9 @@ aHM
 bIO
 aHM
 aHM
-aKx
-aKV
-aKx
+aKU
+wKE
+aLt
 aKw
 aMx
 aMX
@@ -90925,9 +90986,9 @@ aIN
 bCi
 aHM
 aKy
-aKW
-aLt
-aKw
+aKy
+aKy
+aKy
 aMy
 aNc
 aQc
@@ -91181,17 +91242,17 @@ aIg
 aIN
 bID
 aHM
-aKx
+dzF
 aKX
 aLu
-aKw
-aMz
+ggo
+aUj
 aNd
 aQd
 aQC
 aOD
 aOr
-aOq
+wNg
 bdW
 aOq
 aOD
@@ -91438,11 +91499,11 @@ aIh
 aJq
 bxS
 aHM
+cfw
+aKW
 aKx
-aKY
-aKx
-aKw
-aMA
+eRW
+aUj
 aNd
 bxz
 aQD
@@ -91695,10 +91756,10 @@ bId
 bIz
 bSq
 aHM
-aKx
+fkT
 aKY
 aKx
-aKw
+aMC
 aMB
 aNe
 bxA
@@ -91952,11 +92013,11 @@ aHM
 aHM
 aHM
 aHM
-aKw
+vcQ
 aKZ
-aKw
-aKw
-aMC
+tnK
+aKz
+aMz
 aNd
 bxz
 aQE
@@ -92209,9 +92270,9 @@ aJv
 bvF
 ayN
 aHo
-aKz
-aLa
 ayN
+aLa
+aLQ
 aLQ
 aMD
 aNf
@@ -92469,7 +92530,7 @@ aJt
 bwj
 bwi
 aJt
-aJY
+aJt
 aLR
 aNg
 aNU
@@ -92722,13 +92783,13 @@ aFN
 aIk
 aIQ
 aJZ
-aJZ
+aMw
 aJZ
 sIl
 aJZ
+aIQ
+aMF
 aLS
-aMF
-aMF
 aNV
 aOu
 aNd

--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -2787,24 +2787,8 @@
 	name = "\improper Foreward Command Hallwayy"
 	})
 "afo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK"
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "afu" = (
 /obj/effect/floor_decal/corner/blue{
@@ -2997,13 +2981,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "agc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	health = 1e+006
-	},
+/obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/security/security_cell_hallway)
 "age" = (
@@ -3065,23 +3043,27 @@
 /turf/simulated/wall,
 /area/maintenance/security_starboard)
 "agj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "centcom_shuttle_dock_airlock";
+	name = "interior access button";
+	pixel_x = -25;
+	req_one_access = list(13)
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	health = 1e+006
-	},
-/turf/simulated/floor/plating,
-/area/security/security_cell_hallway)
-"agl" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"agl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	tag = "icon-intact (EAST)"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "agm" = (
@@ -8038,8 +8020,7 @@
 /turf/simulated/floor/airless/ceiling,
 /area/exterior/decktwo)
 "apZ" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/maintenance/security_port)
 "aqa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -45112,8 +45093,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/foyer)
 "ieJ" = (
-/turf/simulated/wall,
-/area/exterior/decktwo)
+/obj/item/weapon/rig/pmc/security/green/equipped{
+	req_access = list(1)
+	},
+/obj/item/weapon/rig/pmc/security/green/equipped{
+	req_access = list(1)
+	},
+/obj/item/weapon/rig/pmc/security/green/equipped{
+	req_access = list(1)
+	},
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
 "ieX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -48068,10 +48059,6 @@
 	},
 /turf/simulated/floor/airless/ceiling,
 /area/space)
-"mlj" = (
-/obj/machinery/suit_cycler/security,
-/turf/simulated/floor/tiled,
-/area/security/security_cell_hallway)
 "mme" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 4
@@ -52668,18 +52655,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/central)
 "sbK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "sca" = (
 /obj/effect/floor_decal/corner/grey{
@@ -53537,21 +53516,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "tkp" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/item/weapon/rig/pmc/security/green/equipped{
-	req_access = list(1)
-	},
-/obj/item/weapon/rig/pmc/security/green/equipped{
-	req_access = list(1)
-	},
-/obj/item/weapon/rig/pmc/security/green/equipped{
-	req_access = list(1)
-	},
-/obj/structure/table/rack,
+/obj/machinery/suit_cycler/security,
 /turf/simulated/floor/tiled,
-/area/security/security_cell_hallway)
+/area/maintenance/security_port)
 "tlA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -54690,23 +54657,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/range)
 "uEJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	tag = "icon-intact (EAST)"
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "centcom_shuttle_dock_airlock";
-	name = "interior access button";
-	pixel_x = -28;
-	pixel_y = 26;
-	req_one_access = list(13)
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/r_wall,
 /area/security/security_cell_hallway)
 "uEM" = (
 /obj/structure/cable/green{
@@ -74298,7 +74255,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aab
 aaa
 aaa
 aaa
@@ -78104,7 +78061,7 @@ aaa
 aaa
 aaa
 aaa
-aab
+aaa
 aaa
 aaa
 aaa
@@ -79890,7 +79847,7 @@ aaa
 aaa
 aaa
 aaa
-aab
+aaa
 aaa
 aaa
 aaa
@@ -80919,9 +80876,9 @@ apX
 apX
 apX
 apX
-apX
-apX
-apX
+uEJ
+gxh
+bSe
 apX
 apX
 apX
@@ -81176,9 +81133,9 @@ apX
 apX
 apX
 apX
-afo
-gxh
-sbK
+agc
+bOu
+agc
 apX
 apX
 apX
@@ -81434,7 +81391,7 @@ apX
 apX
 apX
 agc
-bOu
+jJW
 agc
 apX
 apX
@@ -81688,13 +81645,13 @@ apX
 apX
 apX
 apX
-apX
-apX
-agc
-jJW
-agc
-apX
-apX
+bSe
+bSe
+bSe
+rmF
+bSe
+bSe
+bSe
 apX
 apX
 apX
@@ -81945,13 +81902,13 @@ apX
 apX
 apX
 apX
-apX
-aeZ
+bSe
+agm
 agj
-rmF
-agj
+agl
+sbK
 ieJ
-apX
+bSe
 apX
 apX
 apX
@@ -82204,11 +82161,11 @@ bSe
 bSe
 bSe
 bSe
-agl
-uEJ
+amk
+fVI
+amk
 tkp
-arq
-arq
+apZ
 arq
 arq
 arq
@@ -82461,10 +82418,10 @@ alA
 amk
 amO
 bSe
-agm
+afo
 fVI
-mlj
-arq
+amk
+apZ
 apZ
 aqD
 aqe
@@ -82978,7 +82935,7 @@ bSe
 ahm
 aoy
 nrL
-arq
+apZ
 fGq
 aqF
 aro
@@ -83235,7 +83192,7 @@ bSe
 ahF
 aoy
 tgD
-arq
+apZ
 aqE
 aqG
 arq
@@ -83492,7 +83449,7 @@ anr
 ahK
 aoA
 tCR
-arq
+apZ
 aqd
 aqG
 iEH

--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -12424,6 +12424,7 @@
 	id = "trash";
 	name = "disposal mass driver"
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "azA" = (
@@ -21279,6 +21280,7 @@
 	name = "Escape Airlock";
 	req_access = list(13)
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "aQs" = (
@@ -83251,9 +83253,9 @@ arq
 arq
 arq
 arq
-ayb
 aaa
-ayb
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83507,7 +83509,7 @@ arn
 aqG
 lNe
 aqG
-dAz
+arq
 ayb
 azz
 ayb

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -25137,7 +25137,7 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall)
 "ceA" = (
-/obj/effect/shuttle_landmark/arfs/deck3/space/se,
+/obj/effect/shuttle_landmark/arfs/deck3/space/nw,
 /turf/space,
 /area/space)
 "chi" = (
@@ -25510,6 +25510,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"fEo" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/se,
+/turf/space,
+/area/space)
 "fXi" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -25518,10 +25522,6 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_n)
-"ggK" = (
-/obj/effect/shuttle_landmark/arfs/deck3/space/nw,
-/turf/space,
-/area/space)
 "grV" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -26303,6 +26303,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"nMu" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/sw,
+/turf/space,
+/area/space)
 "nMT" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/communicator{
@@ -26982,10 +26986,6 @@
 /obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_w)
-"wGR" = (
-/obj/effect/shuttle_landmark/arfs/deck3/space/sw,
-/turf/space,
-/area/space)
 "wJa" = (
 /obj/machinery/floodlight{
 	dir = 4
@@ -27063,6 +27063,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
@@ -37856,7 +37859,7 @@ aaa
 aaa
 aaa
 aaa
-wGR
+nMu
 aaa
 aaa
 aaa
@@ -41802,7 +41805,7 @@ aaa
 aaa
 aaa
 aaa
-ggK
+ceA
 aaa
 aaa
 aaa
@@ -79486,7 +79489,7 @@ aaa
 aaa
 aaa
 aaa
-ceA
+fEo
 aaa
 aaa
 aaa

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -25100,6 +25100,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"bOs" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "bSj" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -26317,6 +26325,18 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"nJN" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
 "nMm" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
@@ -26430,6 +26450,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
 "pff" = (
@@ -26499,6 +26524,16 @@
 /obj/item/weapon/material/ashtray/glass,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"pPD" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/deckthree/fore)
 "pYJ" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
@@ -27060,6 +27095,15 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"xiW" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
 "xjs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -27149,6 +27193,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"yiM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "ykV" = (
 /obj/random/maintenance/clean,
 /obj/effect/floor_decal/rust,
@@ -58375,7 +58435,7 @@ oaW
 cEw
 jvO
 oaW
-oaW
+nJN
 pbT
 vlu
 rGF
@@ -58633,7 +58693,7 @@ oaW
 oaW
 oaW
 ubH
-duE
+xiW
 duE
 oaW
 duE
@@ -58890,7 +58950,7 @@ aYl
 aYl
 aYl
 aYl
-vyJ
+pPD
 aYl
 aYl
 aYl
@@ -59147,7 +59207,7 @@ aJA
 aUk
 aow
 aUk
-aUk
+bOs
 aUk
 aUk
 aUk
@@ -59404,7 +59464,7 @@ gHu
 gHu
 gHu
 gHu
-gHu
+yiM
 gHu
 gHu
 gHu

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -25137,9 +25137,10 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall)
 "ceA" = (
-/obj/effect/shuttle_landmark/arfs/deck3/space/nw,
-/turf/space,
-/area/space)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/autoname,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "chi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25193,6 +25194,9 @@
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
 "cAl" = (
@@ -25288,6 +25292,12 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"dkg" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "dtu" = (
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
@@ -25339,8 +25349,15 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_w)
+"dTT" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/se,
+/turf/space,
+/area/space)
 "dVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
@@ -25510,10 +25527,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"fEo" = (
-/obj/effect/shuttle_landmark/arfs/deck3/space/se,
-/turf/space,
-/area/space)
 "fXi" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -25683,6 +25696,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
@@ -26235,6 +26251,15 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"nub" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "nwy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -26271,6 +26296,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_n)
 "nEs" = (
@@ -26303,10 +26331,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"nMu" = (
-/obj/effect/shuttle_landmark/arfs/deck3/space/sw,
-/turf/space,
-/area/space)
 "nMT" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/communicator{
@@ -26476,6 +26500,10 @@
 /obj/item/weapon/material/ashtray/glass,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"pVQ" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/nw,
+/turf/space,
+/area/space)
 "pYJ" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
@@ -26552,6 +26580,7 @@
 	pixel_y = 20
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "rbX" = (
@@ -26632,6 +26661,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"sqr" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/sw,
+/turf/space,
+/area/space)
 "sym" = (
 /obj/structure/closet/crate{
 	dir = 1
@@ -26758,6 +26791,10 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"tQs" = (
+/obj/machinery/camera/autoname,
+/turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "tUz" = (
 /obj/machinery/light{
@@ -27004,6 +27041,7 @@
 	pixel_y = 22
 	},
 /obj/random/pottedplant,
+/obj/machinery/camera/autoname,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
 "wPD" = (
@@ -37859,7 +37897,7 @@ aaa
 aaa
 aaa
 aaa
-nMu
+sqr
 aaa
 aaa
 aaa
@@ -41805,7 +41843,7 @@ aaa
 aaa
 aaa
 aaa
-ceA
+pVQ
 aaa
 aaa
 aaa
@@ -42379,7 +42417,7 @@ aaa
 aaa
 aaa
 eUF
-exg
+ceA
 bJT
 qTC
 eUF
@@ -45463,7 +45501,7 @@ aaa
 aaa
 aaa
 eUF
-exg
+ceA
 tdW
 xjs
 eUF
@@ -47264,7 +47302,7 @@ aaa
 eUF
 jnM
 hBT
-jnM
+dkg
 eUF
 aaa
 aaa
@@ -49320,7 +49358,7 @@ aaa
 eUF
 cTt
 tdW
-vgI
+nub
 eUF
 aaa
 aaa
@@ -56259,7 +56297,7 @@ gIE
 gIE
 wPD
 hBT
-jnM
+dkg
 bXQ
 gCi
 oaW
@@ -58313,7 +58351,7 @@ aNF
 avy
 aFI
 bXQ
-jnM
+tQs
 hBT
 jnM
 bXQ
@@ -79489,7 +79527,7 @@ aaa
 aaa
 aaa
 aaa
-fEo
+dTT
 aaa
 aaa
 aaa

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -25137,10 +25137,9 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall)
 "ceA" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/camera/autoname,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
+/obj/effect/shuttle_landmark/arfs/deck3/space/nw,
+/turf/space,
+/area/space)
 "chi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25292,12 +25291,6 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
-"dkg" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
 "dtu" = (
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
@@ -25354,10 +25347,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_w)
-"dTT" = (
-/obj/effect/shuttle_landmark/arfs/deck3/space/se,
-/turf/space,
-/area/space)
 "dVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
@@ -25599,6 +25588,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/excursion/medical)
+"gIu" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/autoname,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "gIE" = (
 /turf/simulated/wall,
 /area/security/checkpoint)
@@ -25782,6 +25776,10 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"iwD" = (
+/obj/machinery/camera/autoname,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "iyW" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
@@ -26135,6 +26133,12 @@
 /obj/effect/shuttle_landmark/arfs/deck3/dockarm/west,
 /turf/space,
 /area/space)
+"mnQ" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "msj" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -26251,15 +26255,6 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"nub" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
 "nwy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -26460,6 +26455,10 @@
 "pyB" = (
 /turf/simulated/wall,
 /area/maintenance/station/deck_three/port_docking_arm)
+"pBy" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/sw,
+/turf/space,
+/area/space)
 "pBU" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -26500,10 +26499,6 @@
 /obj/item/weapon/material/ashtray/glass,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
-"pVQ" = (
-/obj/effect/shuttle_landmark/arfs/deck3/space/nw,
-/turf/space,
-/area/space)
 "pYJ" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
@@ -26522,6 +26517,15 @@
 /obj/effect/shuttle_landmark/arfs/deck3/space/ne,
 /turf/space,
 /area/space)
+"qoH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "qxq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -26661,10 +26665,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
-"sqr" = (
-/obj/effect/shuttle_landmark/arfs/deck3/space/sw,
-/turf/space,
-/area/space)
 "sym" = (
 /obj/structure/closet/crate{
 	dir = 1
@@ -26791,10 +26791,6 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/carpet,
-/area/hallway/station/docking_hall)
-"tQs" = (
-/obj/machinery/camera/autoname,
-/turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "tUz" = (
 /obj/machinery/light{
@@ -27044,6 +27040,10 @@
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"wMc" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/se,
+/turf/space,
+/area/space)
 "wPD" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -37897,7 +37897,7 @@ aaa
 aaa
 aaa
 aaa
-sqr
+pBy
 aaa
 aaa
 aaa
@@ -41843,7 +41843,7 @@ aaa
 aaa
 aaa
 aaa
-pVQ
+ceA
 aaa
 aaa
 aaa
@@ -42417,7 +42417,7 @@ aaa
 aaa
 aaa
 eUF
-ceA
+gIu
 bJT
 qTC
 eUF
@@ -45501,7 +45501,7 @@ aaa
 aaa
 aaa
 eUF
-ceA
+gIu
 tdW
 xjs
 eUF
@@ -47302,7 +47302,7 @@ aaa
 eUF
 jnM
 hBT
-dkg
+mnQ
 eUF
 aaa
 aaa
@@ -49358,7 +49358,7 @@ aaa
 eUF
 cTt
 tdW
-nub
+qoH
 eUF
 aaa
 aaa
@@ -56297,7 +56297,7 @@ gIE
 gIE
 wPD
 hBT
-dkg
+mnQ
 bXQ
 gCi
 oaW
@@ -58351,7 +58351,7 @@ aNF
 avy
 aFI
 bXQ
-tQs
+iwD
 hBT
 jnM
 bXQ
@@ -79527,7 +79527,7 @@ aaa
 aaa
 aaa
 aaa
-dTT
+wMc
 aaa
 aaa
 aaa

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -4409,16 +4409,14 @@
 /area/library)
 "aiM" = (
 /turf/simulated/wall/r_wall,
-/area/holodeck_control)
+/area/hallway/station/docking_hall_airlock_w)
 "aiN" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
-/area/holodeck_control)
+/area/maintenance/station/deck_three/port_docking_arm)
 "aiO" = (
 /turf/simulated/floor/reinforced{
 	name = "Holodeck Projector Floor"
@@ -7904,6 +7902,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "aqa" = (
@@ -18912,6 +18915,10 @@
 /area/rnd/research_restroom{
 	name = "\improper Research Breakroom"
 	})
+"aLG" = (
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "aLI" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
@@ -19996,6 +20003,11 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "aOw" = (
@@ -25014,6 +25026,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"baO" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_s)
 "bcx" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 6
@@ -25023,6 +25043,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hallway)
+"bgY" = (
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
 "brc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
@@ -25032,6 +25060,111 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"btx" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"bxM" = (
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"bzW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_s)
+"bCn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"bDp" = (
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"bJT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"bSj" = (
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"bTJ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"bVJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_w)
+"bVN" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Fore Hallway - Deck 2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"bXQ" = (
+/turf/simulated/wall,
+/area/hallway/station/docking_hall)
+"cbz" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Information Kiosk"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
+"ceA" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/se,
+/turf/space,
+/area/space)
+"chi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
+"cia" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_w)
 "cln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 1
@@ -25042,16 +25175,305 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"clH" = (
+/obj/effect/shuttle_landmark/arfs/deck3/dockarm/south,
+/turf/space,
+/area/space)
+"coU" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"cvS" = (
+/obj/machinery/airlock_sensor{
+	pixel_x = 25
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/map_helper/airlock/atmos/pump_out_internal,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_s)
+"cAl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/airlock_sensor{
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_n)
+"cBR" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_n)
+"cEw" = (
+/obj/random/junk,
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"cMy" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/door/window,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
+"cOO" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_w)
+"cPi" = (
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_s)
+"cTt" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"cVD" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_s)
+"dbZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_s)
+"dtu" = (
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"duE" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"dKe" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"dNc" = (
+/obj/structure/bed/chair/bay,
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"dOF" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Checkpoint"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"dPJ" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	frequency = 1380;
+	id_tag = "dallus_port_arm_w";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_w)
 "dVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"dZs" = (
+/obj/structure/bed/chair/bay/comfy,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"ebl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"eje" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
 "eug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"evD" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/station/docking_hall_airlock_s)
+"exg" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"ezH" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"eAz" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"eBP" = (
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"eNy" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"ePN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"eQh" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"eUF" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/station/docking_hall)
+"eWg" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -27;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"eYL" = (
+/obj/structure/window/reinforced,
+/obj/item/device/radio/headset{
+	pixel_x = -12
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
+"fdE" = (
+/obj/structure/bed/chair/bay{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
 "feL" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 9
@@ -25061,6 +25483,92 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hallway)
+"ffy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"ffT" = (
+/obj/random/trash_pile,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"fAS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"fXi" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_n)
+"ggK" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/nw,
+/turf/space,
+/area/space)
+"grV" = (
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/random/pottedplant,
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"gsi" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"gBl" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"gBt" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"gCi" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"gEp" = (
+/obj/structure/bed/chair/bay{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"gHu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "gHQ" = (
 /obj/effect/floor_decal/fancy_shuttle{
 	fancy_shuttle_tag = "explo"
@@ -25078,12 +25586,37 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/excursion/medical)
+"gIE" = (
+/turf/simulated/wall,
+/area/security/checkpoint)
+"gJT" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"gNC" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
 "gWu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"hbP" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
+	pixel_y = 24;
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_w)
 "hhH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -25091,6 +25624,37 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"hny" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"hnN" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"hoW" = (
+/obj/random/trash_pile,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
 "htM" = (
 /obj/effect/floor_decal/fancy_shuttle{
 	fancy_shuttle_tag = "explo"
@@ -25100,6 +25664,113 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/excursion/medical)
+"hBT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"hFL" = (
+/obj/random/pottedplant,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"hFS" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"hFW" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/random/pottedplant,
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"hKx" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	frequency = 1380;
+	id_tag = "dallus_port_arm_n";
+	pixel_x = -25
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/pump_out_internal,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_n)
+"hSK" = (
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"hUc" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -28;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"hXb" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/security/checkpoint)
+"ibI" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/sign/directions/stairs_down{
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"ihu" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/maintenance/security,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"iuR" = (
+/obj/machinery/light,
+/turf/simulated/open,
+/area/hallway/primary/deckthree/fore)
+"iwz" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window{
+	dir = 2;
+	req_one_access = list(1,52)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"iyW" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
 "iGa" = (
 /obj/machinery/door/airlock/angled_tgmc{
 	dir = 4;
@@ -25110,6 +25781,41 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/excursion/general)
+"iIb" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"iNh" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"iOU" = (
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"iUf" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
 "iWt" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -25122,6 +25828,215 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"jhb" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
+	pixel_x = -25;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_n)
+"jhx" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"jnM" = (
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"jpN" = (
+/obj/machinery/light,
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/airlock_sensor{
+	pixel_y = -25;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_s)
+"jqY" = (
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"jud" = (
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"juG" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/random/junk,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"jvO" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"jwM" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/simulated/open,
+/area/hallway/primary/deckthree/fore)
+"jwP" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"jBH" = (
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"jFU" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_n)
+"jKo" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"jTS" = (
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/airlock_sensor{
+	pixel_x = -24;
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_w)
+"jXW" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"kaU" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"kaV" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"kva" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"kwG" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"kDP" = (
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"kHW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -28;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"kME" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"lcT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"lfI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_s)
+"ljk" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
 "lnC" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -25131,6 +26046,79 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"ltj" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -27;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"lvi" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"lyc" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"lDX" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"lHD" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/obj/random/junk,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"lVr" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"lVs" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/red{
+	pixel_x = -5
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/blue{
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"mlY" = (
+/obj/effect/shuttle_landmark/arfs/deck3/dockarm/west,
+/turf/space,
+/area/space)
 "msj" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -25140,6 +26128,39 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"mvu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"mxO" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_s)
+"mAz" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -28;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"mDx" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/clothing/mask/smokable/cigarette/cigar{
+	pixel_x = 9;
+	pixel_y = 1
+	},
+/obj/item/weapon/flame/lighter/zippo{
+	pixel_y = 9;
+	pixel_x = -6
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
 "mER" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 6
@@ -25152,10 +26173,206 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hallway)
+"mId" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_s)
+"mJT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"mKe" = (
+/turf/simulated/wall,
+/area/crew_quarters/sleep{
+	name = "\improper Ball Room"
+	})
+"mMq" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_n)
+"mTx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_w)
 "nao" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"ngC" = (
+/obj/random/trash,
+/obj/machinery/floodlight{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"njf" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/random/trash,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"nwy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_w)
+"nyd" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/window/reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/blue{
+	pixel_x = 5
+	},
+/obj/item/weapon/pen/red{
+	pixel_x = -5
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
+"nDX" = (
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/airlock_sensor{
+	pixel_x = 25
+	},
+/obj/effect/map_helper/airlock/atmos/pump_out_internal,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_n)
+"nEs" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_n)
+"nHu" = (
+/obj/structure/bed/chair/bay/comfy{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"nHZ" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"nJm" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"nMm" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"nMT" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/communicator{
+	pixel_x = -10
+	},
+/obj/item/device/communicator{
+	pixel_x = -10
+	},
+/obj/item/device/communicator{
+	pixel_x = -5
+	},
+/obj/item/device/communicator,
+/obj/item/device/communicator{
+	pixel_x = 5
+	},
+/obj/item/device/communicator{
+	pixel_x = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"nQb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"oaW" = (
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"ojX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"oon" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"oym" = (
+/obj/random/maintenance/clean,
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"oLi" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_s)
 "oOP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/door/window/southleft{
@@ -25167,6 +26384,265 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"oVj" = (
+/obj/structure/filingcabinet/security,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"oXR" = (
+/obj/random/maintenance/clean,
+/obj/structure/table/rack,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"paY" = (
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"pbT" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"pff" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/sign/deck/third{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"puk" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"pyf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"pyB" = (
+/turf/simulated/wall,
+/area/maintenance/station/deck_three/port_docking_arm)
+"pBU" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/station/docking_hall_airlock_w)
+"pCn" = (
+/obj/random/maintenance/clean,
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"pND" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"pNL" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"pNS" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/material/ashtray/glass,
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"pYJ" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"pYW" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_n)
+"qgJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_n)
+"qiG" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/ne,
+/turf/space,
+/area/space)
+"qxq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"qzf" = (
+/obj/random/trash,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"qDI" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/handcuffs,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"qNa" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"qOs" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/hallway/station/docking_hall)
+"qTC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"qXe" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"rbX" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/blue{
+	pixel_x = 5
+	},
+/obj/item/weapon/pen/red{
+	pixel_x = -5
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
+"rhZ" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"rlq" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_s)
+"rnI" = (
+/obj/effect/shuttle_landmark/arfs/deck3/dockarm/north,
+/turf/space,
+/area/space)
+"rGF" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"rJo" = (
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"sfJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"sgl" = (
+/turf/simulated/open,
+/area/hallway/primary/deckthree/fore)
+"siy" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/station/docking_hall_airlock_w)
+"skg" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	frequency = 1380;
+	id_tag = "dallus_port_arm_s";
+	pixel_x = -25
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/pump_out_internal,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_s)
+"sym" = (
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"syU" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/security/checkpoint)
 "sBs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/door/window/southright{
@@ -25175,6 +26651,127 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"sBW" = (
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/security_port)
+"sDt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_s)
+"sTs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_s)
+"sWI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"tat" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"tcR" = (
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"tdW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"tgK" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/headset{
+	pixel_x = -5
+	},
+/obj/item/device/radio/headset,
+/obj/item/device/radio/headset{
+	pixel_x = 10
+	},
+/obj/item/device/radio/headset{
+	pixel_x = 5
+	},
+/obj/item/device/radio/headset{
+	pixel_x = 15
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"tmY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_airlock_n)
+"tGn" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_s)
+"tIC" = (
+/obj/machinery/light,
+/obj/structure/bed/chair/bay{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"tPk" = (
+/obj/structure/bed/chair/bay{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -30
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"tUz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/bay,
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"tUH" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"ubH" = (
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
 "uie" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -25182,10 +26779,297 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"uiI" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_n)
 "unD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/plating,
 /area/exploration/hanger)
+"uCB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_n)
+"uGe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"uQc" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"uQO" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash_pile,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/security_port)
+"uRI" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/station/docking_hall)
+"vgI" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"vlu" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"vpj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"vrt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_w)
+"vuV" = (
+/obj/random/trash_pile,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"vwJ" = (
+/obj/structure/closet/crate{
+	dir = 8
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"vyJ" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/hallway/primary/deckthree/fore)
+"vCT" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall)
+"vHH" = (
+/obj/random/trash_pile,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"vQN" = (
+/obj/random/trash,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"vVq" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"vWN" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/station/deck_three/port_docking_arm)
+"vWR" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"vZg" = (
+/obj/machinery/door/airlock/glass_external{
+	locked = 1
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_n)
+"wag" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"wlA" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"wpd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"wtT" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"wGa" = (
+/obj/machinery/airlock_sensor{
+	pixel_y = 24
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_helper/airlock/atmos/pump_out_internal,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/station/docking_hall_airlock_w)
+"wGR" = (
+/obj/effect/shuttle_landmark/arfs/deck3/space/sw,
+/turf/space,
+/area/space)
+"wJa" = (
+/obj/machinery/floodlight{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_port)
+"wJu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/wall/r_wall,
+/area/hallway/station/docking_hall_airlock_n)
+"wKh" = (
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/obj/random/pottedplant,
+/turf/simulated/floor/carpet,
+/area/hallway/station/docking_hall)
+"wPD" = (
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"xih" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"xjs" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"xoD" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"xxE" = (
+/obj/machinery/door/window{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
+"xIH" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"xLK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/checkpoint)
+"xOu" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/station/docking_hall_airlock_n)
 "xSR" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -25198,6 +27082,37 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"xXw" = (
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"ybj" = (
+/obj/random/trash_pile,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
+"ykV" = (
+/obj/random/maintenance/clean,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/deck_three/port_docking_arm)
 
 (1,1,1) = {"
 aaa
@@ -35941,7 +37856,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wGR
 aaa
 aaa
 aaa
@@ -38149,7 +40064,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+mlY
 aaa
 aaa
 aaa
@@ -38662,9 +40577,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aiM
+hbP
+aiM
 aaa
 aaa
 aaa
@@ -38919,9 +40834,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aiM
+wGa
+vrt
 aaa
 aaa
 aaa
@@ -39176,9 +41091,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aiM
+cia
+pBU
 aaa
 aaa
 aaa
@@ -39433,9 +41348,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aiM
+dPJ
+mTx
 aaa
 aaa
 aaa
@@ -39689,11 +41604,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aiM
+aiM
+cOO
+mTx
+aiM
 aaa
 aaa
 aaa
@@ -39887,6 +41802,7 @@ aaa
 aaa
 aaa
 aaa
+ggK
 aaa
 aaa
 aaa
@@ -39945,12 +41861,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+siy
+jTS
+nwy
+bVJ
+siy
 aaa
 aaa
 aaa
@@ -40203,11 +42118,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+wPD
+ojX
+sWI
+eUF
 aaa
 aaa
 aaa
@@ -40460,11 +42375,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+exg
+bJT
+qTC
+eUF
 aaa
 aaa
 aaa
@@ -40717,11 +42632,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+rJo
+ePN
+sfJ
+eUF
 aaa
 aaa
 aaa
@@ -40974,11 +42889,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -41231,11 +43146,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vCT
+jnM
+hBT
+wag
+vCT
 aaa
 aaa
 aaa
@@ -41488,11 +43403,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -41745,11 +43660,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -42002,11 +43917,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+cTt
+tdW
+vgI
+eUF
 aaa
 aaa
 aaa
@@ -42259,11 +44174,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -42516,11 +44431,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+ebl
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -42773,11 +44688,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vCT
+aLG
+hnN
+aLG
+vCT
 aaa
 aaa
 aaa
@@ -43030,11 +44945,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -43287,11 +45202,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+rJo
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -43544,11 +45459,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+exg
+tdW
+xjs
+eUF
 aaa
 aaa
 aaa
@@ -43801,11 +45716,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+wPD
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -44058,11 +45973,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -44312,17 +46227,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wJu
+cBR
+uCB
+uCB
+cAl
+qxq
+jpN
+lfI
+lfI
+bzW
+sDt
 aaa
 aaa
 aaa
@@ -44567,21 +46482,21 @@ aaa
 aaa
 aaa
 aaa
+rnI
 aaa
+jhb
+hKx
+mMq
+uiI
+tmY
+wpd
+sTs
+oLi
+rlq
+skg
+cVD
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+clH
 aaa
 aaa
 aaa
@@ -44826,17 +46741,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aYH
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vZg
+nDX
+pYW
+fXi
+qgJ
+ffy
+mId
+baO
+dbZ
+cvS
+tGn
 aaa
 aaa
 aaa
@@ -45083,17 +46998,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jFU
+jFU
+xOu
+jFU
+nEs
+hBT
+cPi
+mxO
+evD
+mxO
+mxO
 aaa
 aaa
 aaa
@@ -45343,11 +47258,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -45600,11 +47515,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+rJo
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -45857,11 +47772,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+exg
+tdW
+xjs
+eUF
 aaa
 aaa
 aaa
@@ -46114,11 +48029,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+wPD
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -46371,11 +48286,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -46628,11 +48543,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vCT
+aLG
+hnN
+aLG
+vCT
 aaa
 aaa
 aaa
@@ -46885,11 +48800,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -47142,11 +49057,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -47399,11 +49314,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+cTt
+tdW
+vgI
+eUF
 aaa
 aaa
 aaa
@@ -47656,11 +49571,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+ebl
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -47913,11 +49828,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -48170,11 +50085,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vCT
+jnM
+hBT
+wag
+vCT
 aaa
 aaa
 aaa
@@ -48427,11 +50342,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -48684,11 +50599,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -48941,11 +50856,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+rJo
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -49198,11 +51113,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+lcT
+tdW
+xjs
+eUF
 aaa
 aaa
 aaa
@@ -49455,11 +51370,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eUF
+jnM
+hBT
+jnM
+eUF
 aaa
 aaa
 aaa
@@ -49712,11 +51627,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vCT
+jnM
+hBT
+jnM
+vCT
 aaa
 aaa
 aaa
@@ -49946,53 +51861,53 @@ aTJ
 aTJ
 aTJ
 aTJ
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aqd
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+vCT
+vCT
+vCT
+vCT
+nHZ
+uRI
+nHZ
+vCT
+vCT
+vCT
+vCT
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+vWN
+aRf
 aSH
 aNZ
 aaE
@@ -50202,54 +52117,54 @@ aMq
 avy
 aCu
 anz
-aTJ
-aTJ
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aqd
+aNF
+aMe
+aWd
+uQO
+sBW
+kaU
+aWd
+avy
+avy
+avy
+aFI
+acD
+aWd
+avy
+acD
+aNF
+axZ
+aFI
+aNF
+aMe
+axn
+bXQ
+mDx
+gEp
+jnM
+jnM
+hBT
+jnM
+jnM
+gEp
+pNS
+bXQ
+oaW
+oaW
+bDp
+jhx
+oaW
+vlu
+pyB
+oaW
+bDp
+vWR
+pYJ
+oaW
+pyB
+sym
+xih
+aRf
 aSH
 aNZ
 aaE
@@ -50461,52 +52376,52 @@ azs
 aNF
 aFI
 aNF
-aTJ
-aTJ
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aqd
+aWd
+aWd
+aWd
+acD
+aWd
+coU
+pCn
+avj
+aEX
+aNF
+aWd
+aMe
+aNF
+avj
+aWd
+avy
+acD
+aNF
+avy
+bXQ
+tUz
+dtu
+jnM
+exg
+tdW
+vgI
+jnM
+dtu
+tIC
+bXQ
+oaW
+pyB
+pYJ
+duE
+oaW
+bDp
+pyB
+vlu
+bDp
+njf
+oaW
+jhx
+pyB
+jhx
+oaW
+aRf
 aSH
 aNZ
 aNZ
@@ -50720,50 +52635,50 @@ avy
 aEX
 avy
 anz
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aqd
+aWd
+aMe
+aWd
+aWd
+aWd
+aWd
+aWd
+axZ
+aWd
+axZ
+aWd
+aWd
+aWd
+wlA
+aNF
+aFA
+acD
+bXQ
+dNc
+dtu
+jnM
+nMT
+pNL
+tgK
+jnM
+dtu
+fdE
+bXQ
+oaW
+pyB
+jhx
+duE
+duE
+oaW
+iyW
+duE
+oaW
+pyB
+puk
+oaW
+pyB
+vlu
+jhx
+aRf
 aSH
 aNZ
 aNZ
@@ -50977,50 +52892,50 @@ avy
 aEX
 acD
 aCu
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aqd
+aWd
+avy
+aEX
+aNF
+acD
+aMe
+avy
+aNF
+aWd
+aFI
+jXW
+wJa
+aWd
+aWd
+aWd
+aWd
+aWd
+bXQ
+grV
+dtu
+jnM
+rbX
+eje
+eYL
+jnM
+dtu
+hFL
+bXQ
+oaW
+pyB
+ezH
+kDP
+oaW
+jhx
+pyB
+oaW
+ezH
+pyB
+duE
+duE
+pyB
+puk
+oaW
+aRf
 aSH
 aNZ
 aNZ
@@ -51234,50 +53149,50 @@ avj
 aFI
 aMq
 avy
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aqd
+aWd
+aMe
+aNF
+aFI
+aEX
+aNF
+aNF
+aMe
+aWd
+avy
+aNF
+aNF
+axZ
+aNF
+aNF
+fAS
+aNF
+qOs
+dtu
+dtu
+jnM
+cbz
+chi
+xxE
+jnM
+dtu
+dtu
+qOs
+pYJ
+pyB
+pyB
+pyB
+pyB
+oaW
+pyB
+pyB
+pyB
+pyB
+oaW
+oym
+pyB
+ezH
+jhx
+aRf
 aSH
 aNZ
 aaE
@@ -51491,50 +53406,50 @@ aRu
 aNF
 aEX
 aNF
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aqd
+axZ
+aNF
+aNF
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aMe
+aNF
+avy
+aWd
+aWd
+aWd
+aFA
+rhZ
+bXQ
+wKh
+dtu
+jnM
+iUf
+cMy
+nyd
+jnM
+dtu
+hFW
+bXQ
+duE
+gCi
+rGF
+iIb
+pyB
+puk
+pyB
+bDp
+oaW
+oaW
+vlu
+oaW
+pyB
+oaW
+bDp
+aRf
 aSH
 aNZ
 aaE
@@ -51748,49 +53663,49 @@ aNF
 avy
 aNF
 aYv
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aWd
+aNF
+aNF
+axZ
+aNF
+aFI
+nJm
+aNF
+aWd
+aNF
+aNF
+aEX
+aWd
+axn
+aWd
+acD
+eNy
+bXQ
+dNc
+dtu
+jnM
+vVq
+pNL
+vVq
+jnM
+dtu
+tPk
+bXQ
+duE
+oaW
+duE
+duE
+pyB
+oaW
+pyB
+jhx
+duE
+puk
+oaW
+duE
+pyB
+jhx
+pYJ
 aRf
 atf
 aSH
@@ -52005,49 +53920,49 @@ aCq
 aWd
 aWd
 axZ
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aWd
+aNF
+aFI
+aWd
+aWd
+aWd
+aWd
+aMe
+aNF
+aNF
+awW
+avy
+aWd
+aNF
+aWd
+aNF
+lVr
+bXQ
+tUz
+dtu
+jnM
+exg
+xXw
+vgI
+jnM
+dtu
+tIC
+bXQ
+oaW
+oaW
+duE
+vlu
+iyW
+oaW
+pyB
+jhx
+oaW
+pyB
+pyB
+pyB
+pyB
+oaW
+duE
 aRf
 aRf
 aRf
@@ -52262,52 +54177,52 @@ aEX
 aWd
 azs
 aEX
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aWd
+ljk
+aEX
+aNF
+aNF
+avj
+aWd
+avy
+aNF
+aEX
+aFI
+avj
+aWd
+aNF
+aFI
+avy
+vwJ
+bXQ
+lDX
+dtu
+hFS
+lyc
+kva
+jnM
+jnM
+dtu
+iOU
+bXQ
+pYJ
+bDp
+dKe
+oaW
+pyB
+jhx
+pyB
+duE
+oaW
+oaW
+jhx
+oaW
+pyB
+duE
+duE
+pyB
+dZs
+nHu
 afY
 aMx
 aTr
@@ -52519,52 +54434,52 @@ aHM
 aWd
 atb
 aEX
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aWd
+avj
+aNF
+aNF
+aEX
+aNF
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+gIE
+gIE
+syU
+syU
+gIE
+bVN
+uRI
+bVN
+bXQ
+bXQ
+bXQ
+bXQ
+oaW
+pyB
+pyB
+pyB
+pyB
+oaW
+pyB
+oaW
+bDp
+oaW
+duE
+vlu
+pyB
+bDp
+duE
+pyB
+jKo
+duE
 afY
 axT
 axT
@@ -52776,52 +54691,52 @@ aWd
 aWd
 aMq
 aEX
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aWd
+acD
+aNF
+aWd
+qzf
+avy
+aNF
+aNF
+aMe
+acD
+aNF
+aFI
+aNF
+avy
+tcR
+avj
+gIE
+jBH
+oVj
+lVs
+syU
+jnM
+hBT
+jnM
+bXQ
+oaW
+oaW
+oaW
+duE
+pyB
+jud
+ezH
+pyB
+oaW
+pyB
+iyW
+pyB
+pyB
+oaW
+oaW
+oaW
+pYJ
+tUH
+iyW
+duE
+bDp
 afY
 aMx
 aTr
@@ -53033,52 +54948,52 @@ avj
 aNF
 aNF
 aNF
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aWd
+aWd
+axZ
+aWd
+eAz
+avy
+aEX
+aFI
+aNF
+gNC
+aNF
+aNF
+aMe
+aNF
+aNF
+avy
+hXb
+hSK
+tat
+xoD
+syU
+gBt
+hBT
+jnM
+bXQ
+oaW
+vlu
+pyB
+pyB
+pyB
+oaW
+duE
+pyB
+oaW
+pyB
+oaW
+duE
+pyB
+ezH
+pND
+oaW
+duE
+duE
+pyB
+puk
+vlu
 afY
 axT
 axT
@@ -53290,57 +55205,57 @@ aMs
 aNF
 aFA
 aFI
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
+aWd
+aNF
+aNF
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aFI
+acD
+gIE
+qXe
+mvu
+oon
+syU
+gBt
+hBT
+bTJ
+bXQ
+oaW
+oaW
+pyB
+duE
+oaW
+jhx
+vlu
+pyB
+bDp
+pyB
+oaW
+oaW
+pyB
+pyB
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
 aAg
 ale
 aqR
@@ -53547,46 +55462,46 @@ acD
 aEX
 aEX
 aXb
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aiN
+aWd
+aMe
+aNF
+aNF
+avy
+aNF
+aNF
+eBP
+aNF
+avy
+aMe
+aNF
+avj
+aWd
+avy
+aNF
+gIE
+bSj
+kME
+kwG
+iwz
+gBt
+hBT
+gBl
+bXQ
+vlu
+bDp
+pyB
+bDp
+oaW
+pYJ
+oaW
+pyB
+oaW
+pyB
+bDp
+pYJ
+oaW
+oaW
+aiV
 aiO
 aiO
 aiQ
@@ -53597,7 +55512,7 @@ aiO
 aiO
 aiO
 aiO
-aiM
+aiV
 aiV
 aiV
 aiV
@@ -53804,46 +55719,46 @@ aNF
 aEX
 aEX
 aGG
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aiN
+aWd
+aNF
+aNF
+aNF
+avy
+aNF
+aMe
+aNF
+acD
+aNF
+aNF
+aNF
+aNF
+aWd
+aWd
+axZ
+gIE
+bgY
+kME
+hSK
+gIE
+exg
+tdW
+vgI
+bXQ
+oaW
+oaW
+pyB
+pyB
+pyB
+iyW
+pyB
+pyB
+oaW
+pyB
+oaW
+jhx
+oaW
+oaW
+aiV
 aiO
 aiO
 aiO
@@ -54061,46 +55976,46 @@ aRT
 aRT
 azV
 aGG
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aiN
+aWd
+axZ
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aNF
+aNF
+gIE
+qDI
+xLK
+nQb
+dOF
+uGe
+wtT
+jnM
+bXQ
+jhx
+oaW
+kaV
+hoW
+eQh
+vlu
+xIH
+ffT
+jhx
+pyB
+vlu
+jhx
+oaW
+oym
+aiV
 aiO
 aiO
 aiO
@@ -54318,46 +56233,46 @@ aYf
 aRT
 awW
 aGG
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aoo
-aoo
-aoo
-aoo
-aiN
+aWd
+avy
+aNF
+acD
+aFI
+aNF
+aNF
+aNF
+oXR
+aNF
+aFI
+aNF
+acD
+aNF
+aFI
+avy
+gIE
+gIE
+gIE
+gIE
+gIE
+wPD
+hBT
+jnM
+bXQ
+gCi
+oaW
+jhx
+oaW
+oaW
+oaW
+duE
+oaW
+oaW
+iyW
+duE
+oaW
+duE
+oaW
+aiV
 aiO
 aiO
 aiO
@@ -54368,7 +56283,7 @@ aiO
 aiO
 aiO
 aiO
-aiM
+aiV
 aiY
 ajb
 ajf
@@ -54575,46 +56490,46 @@ aSt
 aRT
 aNF
 aMq
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aoo
-aoo
-aoo
-aoo
-aiN
+aWd
+aNF
+aNF
+aNF
+aFI
+aNF
+acD
+aNF
+aNF
+aNF
+aMe
+avy
+aNF
+aNF
+aNF
+aMe
+aNF
+aNF
+aMe
+aNF
+bXQ
+rJo
+hBT
+wag
+bXQ
+iIb
+oaW
+oaW
+oaW
+vlu
+jhx
+oaW
+oaW
+vlu
+pyB
+oaW
+duE
+tUH
+duE
+aiV
 aiO
 aiO
 aiO
@@ -54832,46 +56747,46 @@ aYp
 aRT
 aHM
 aNF
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aoo
-aoo
-aoo
-aoo
-aiN
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+aFI
+awW
+bXQ
+jwP
+hBT
+jnM
+bXQ
+rGF
+duE
+pyB
+iyW
+pyB
+pyB
+pyB
+pyB
+oaW
+pyB
+jhx
+ybj
+lHD
+oaW
+aiV
 aiO
 aiO
 aiO
@@ -55089,46 +57004,46 @@ aWv
 aRT
 aEX
 aFA
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aaa
-aaa
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aiN
+aWd
+vHH
+aFI
+aNF
+aNF
+aNF
+acD
+aNF
+uQc
+avj
+aNF
+aMe
+aNF
+aFA
+aNF
+acD
+aNF
+aWd
+avj
+aNF
+bXQ
+exg
+tdW
+vgI
+bXQ
+pyB
+oaW
+pyB
+duE
+oaW
+pYJ
+jhx
+pyB
+duE
+pyB
+oaW
+juG
+vuV
+oaW
+aiV
 aiO
 aiO
 aiO
@@ -55139,7 +57054,7 @@ aiO
 aiO
 aiO
 aiO
-aiM
+aiV
 ajK
 ajd
 ajf
@@ -55346,46 +57261,46 @@ aYB
 aRT
 aCu
 avy
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aiN
+aWd
+nMm
+avy
+gNC
+aNF
+aMe
+aNF
+aFI
+aNF
+avy
+awW
+avy
+avy
+aNF
+aMe
+aNF
+aFA
+aWd
+lVr
+aFA
+bXQ
+jnM
+hBT
+jnM
+bXQ
+bDp
+vlu
+pyB
+hny
+oaW
+oaW
+oaW
+pyB
+bDp
+pyB
+duE
+oaW
+duE
+tUH
+aiV
 aiO
 aiO
 aiO
@@ -55603,46 +57518,46 @@ aRT
 aRT
 aWd
 aLp
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aWd
+aWd
+aWd
+aWd
+axZ
+aWd
+aWd
+aWd
+aWd
+aWd
+aWd
+axZ
+aWd
+aWd
+aWd
+aFI
+avy
+aWd
+eNy
+aNF
+qOs
+jnM
+hBT
+jnM
+qOs
+oaW
+duE
+pyB
 aiN
+tUH
+duE
+duE
+pyB
+vlu
+pyB
+oaW
+oaW
+ykV
+oaW
+aiV
 aiO
 aiO
 aiO
@@ -55860,46 +57775,46 @@ aNF
 acD
 aNF
 aEX
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aiN
+aWd
+paY
+ihu
+gsi
+aFI
+aNF
+avy
+acD
+aWd
+aFI
+aNF
+aNF
+aFI
+aNF
+aWd
+aNF
+aNF
+aWd
+vQN
+aNF
+bXQ
+jnM
+hBT
+jnM
+bXQ
+tUH
+gJT
+pyB
+oaW
+oaW
+vlu
+jhx
+pyB
+oaW
+pyB
+oaW
+oaW
+oaW
+oaW
+aiV
 aiO
 aiO
 aiO
@@ -55910,7 +57825,7 @@ aiO
 aiO
 aiO
 aiS
-aiM
+aiV
 aiV
 aiV
 aiV
@@ -56117,60 +58032,60 @@ aXP
 aXP
 aEX
 aNF
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aoo
-aoo
-aoo
+axZ
+aNF
+aNF
+avy
+avy
+aFI
+aNF
+aMe
+aWd
+avj
+aNF
+avy
+aNF
+acD
+aWd
+axZ
+aWd
+aWd
+avy
+aMe
+bXQ
+jnM
+hBT
+gBl
+bXQ
+pyB
+oaW
+pyB
+pyB
+pyB
+pyB
+iyW
+pyB
+oaW
+pyB
+pyB
+pyB
+pyB
+iyW
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+aiV
+qNa
+hny
+ezH
 afV
 akf
 akj
@@ -56374,60 +58289,60 @@ aSW
 aXP
 azV
 avy
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aWd
+ljk
+aNF
+aFI
+aNF
+jqY
+aNF
+avy
+aWd
+acD
+aFI
+aNF
+aNF
+avj
+aWd
+aNF
+aNF
+aNF
+avy
+aFI
+bXQ
+jnM
+hBT
+jnM
+bXQ
+ezH
+vlu
+oaW
+rGF
+iIb
+gCi
+oaW
+oaW
+pYJ
+oaW
+oaW
+oaW
+oaW
+duE
+oaW
+oaW
+oaW
+cEw
+jvO
+oaW
+oaW
+pbT
+vlu
+rGF
+iIb
+gCi
+duE
+bDp
+duE
 afV
 aFf
 ajq
@@ -56631,60 +58546,60 @@ aNF
 avy
 avy
 axn
-aTJ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aWd
+aNF
+ngC
+eNy
+btx
+rhZ
+aNF
+aNF
+aWd
+avy
+avy
+aNF
+aNF
+avy
+aWd
+aNF
+pCn
+aFI
+aNF
+avj
+bXQ
+jnM
+hBT
+jnM
+bXQ
+bxM
+oaW
+jhx
+vlu
+oaW
+oaW
+ubH
+oaW
+oaW
+oaW
+oaW
+bDp
+oaW
+vlu
+duE
+bDp
+oaW
+oaW
+oaW
+oaW
+ubH
+duE
+duE
+oaW
+duE
+duE
+oaW
+duE
+bDp
 afV
 ajm
 ajC
@@ -56895,6 +58810,24 @@ aYl
 aYl
 aYl
 aYl
+vyJ
+aYl
+aYl
+aYl
+aYl
+aYl
+aYl
+aYl
+aYl
+aYl
+aYl
+aYl
+aYl
+bXQ
+aLG
+hnN
+aLG
+bXQ
 aYl
 aYl
 aYl
@@ -56916,25 +58849,7 @@ aYl
 aYl
 aYl
 aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
-aYl
+vyJ
 aYl
 aYl
 aYl
@@ -57128,7 +59043,7 @@ aWd
 aWJ
 aYl
 aUk
-aJA
+kHW
 aUk
 aow
 aUk
@@ -57148,7 +59063,7 @@ aUk
 aJA
 aow
 aUk
-aUk
+hUc
 ajW
 aUk
 aUk
@@ -57164,10 +59079,10 @@ aUk
 aUk
 aUk
 aJA
-aUk
-aUk
-aUk
 aow
+aUk
+aUk
+mJT
 aUk
 aUk
 aUk
@@ -57185,7 +59100,7 @@ aUk
 aUk
 aUk
 aUk
-aUk
+eWg
 aUk
 aJA
 aUk
@@ -57207,7 +59122,7 @@ aIj
 apw
 aLy
 aMa
-aMa
+ltj
 aMa
 aMa
 aMa
@@ -57227,7 +59142,7 @@ aTv
 apC
 aMa
 aMa
-aMa
+mAz
 aMa
 aMa
 ajh
@@ -57389,7 +59304,7 @@ aIh
 aIh
 apR
 anq
-anq
+pyf
 anq
 aGy
 aVy
@@ -57424,35 +59339,35 @@ anq
 anq
 anq
 anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-aGy
-aVy
+lvi
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+iNh
+vpj
 aOv
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
-anq
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
+gHu
 apZ
 aAE
 aQx
@@ -57945,9 +59860,9 @@ aYl
 aYl
 aYl
 aYl
-aYl
-aYl
-aYl
+pff
+ayM
+ibI
 aYl
 aYl
 aYl
@@ -58201,15 +60116,15 @@ aoo
 aoo
 aoo
 aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aYl
+aUk
+aUk
+aUk
+jwM
+sgl
+sgl
+sgl
+aYl
 aoo
 aoo
 aoo
@@ -58458,15 +60373,15 @@ aoo
 aoo
 aoo
 aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aYl
+bCn
+aUk
+aUk
+sgl
+sgl
+sgl
+iuR
+aYl
 aoo
 aoo
 aoo
@@ -58715,15 +60630,15 @@ aoo
 aoo
 aoo
 aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aYl
+aUk
+aUk
+aUk
+sgl
+sgl
+sgl
+sgl
+aYl
 aoo
 aoo
 aoo
@@ -58972,15 +60887,15 @@ aoo
 aoo
 aoo
 aoo
-aoo
-aoo
-aoo
-afu
-afu
-afu
-afu
-afu
-afu
+aYl
+aYl
+aYl
+mKe
+mKe
+mKe
+mKe
+mKe
+mKe
 afu
 afu
 aoo
@@ -77571,7 +79486,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ceA
 aaa
 aaa
 aaa
@@ -81276,7 +83191,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+qiG
 aaa
 aaa
 aaa

--- a/maps/Arfs/arfs_areas.dm
+++ b/maps/Arfs/arfs_areas.dm
@@ -115,6 +115,14 @@
 	name = "\improper Residential Dock"
 	icon_state = "gutsdorms"
 	icon = 'maps/Arfs/arfs_areas.dmi'
+/area/hallway/station/docking_hall
+	name = "\improper Deck Three - Port Docking Arm Hallway"
+/area/hallway/station/docking_hall_airlock_n
+	name = "\improper Deck Three - Port Docking Arm, Fore Airlock"
+/area/hallway/station/docking_hall_airlock_s
+	name = "\improper Deck Three - Port Docking Arm, Aft Airlock"
+/area/hallway/station/docking_hall_airlock_w
+	name = "\improper Deck Three - Port Docking Arm, Port Airlock"
 
 //MAINT
 
@@ -143,6 +151,8 @@
 /area/maintenance/game_room
 	name = "Game Room"
 	icon_state = "amaint"
+/area/maintenance/station/deck_three/port_docking_arm
+	name = "\improper Deck Three - Port Docking Arm Maintenance"
 
 //Underbelly Maintenance
 
@@ -292,3 +302,5 @@
 	name = "\improper Explorationn Waiting Room"
 	icon_state = "exploration"
 	icon = 'maps/arfs/arfs_areas.dmi'
+
+//airlocks

--- a/maps/Arfs/arfs_defines.dm
+++ b/maps/Arfs/arfs_defines.dm
@@ -245,7 +245,11 @@
 		"arfs_excursion_hangar",
 		"arfs_dock_south", //Deck 3, Port Arm, South Dock
 		"arfs_dock_north", //Deck 3, Port Arm, North Dock
-		"arfs_dock_west"   //Deck 3, Port Arm, West Dock
+		"arfs_dock_west",   //Deck 3, Port Arm, West Dock
+		"arfs_space_nw", //Deck 3, NW space
+		"arfs_space_ne", //Deck 3, NE space
+		"arfs_space_sw", //Deck 3, SW space
+		"arfs_space_se"  //Deck 3, SE space
 		)
 
 	initial_restricted_waypoints = list(

--- a/maps/Arfs/arfs_defines.dm
+++ b/maps/Arfs/arfs_defines.dm
@@ -79,7 +79,7 @@
 	overmap_size = 35
 	overmap_z = Z_LEVEL_CENTCOM_ARFS
 	overmap_event_areas = 75
-	
+
 	lateload_z_levels = list(
 		list("V3b Asteroid Field"),
 		list("Desert Planet - Z1 Beach","Desert Planet - Z2 Cave"),
@@ -118,7 +118,7 @@
 	seed_submaps(list(Z_LEVEL_MINING_DANGER_ARFS), 300, /area/mine/unexplored, /datum/map_template/underdark)
 	new /datum/random_map/automata/cave_system(null, 1, 1, Z_LEVEL_MINING_DANGER_ARFS, world.maxx, world.maxy) // Create the mining Z-level.
 	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_MINING_DANGER_ARFS, world.maxx, world.maxy)         // Create the mining ore distribution map.
-	
+
 	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_SPACE_ROCKS, world.maxx, world.maxy) // Create the mining Z-level.
 	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_SPACE_ROCKS, 64, 64)         // Create the mining ore distribution map.
 
@@ -228,12 +228,12 @@
 
 /obj/effect/overmap/visitable/ship/arfs
 	name = "ARFS Dallus"	// Name of the location on the overmap.
-	desc = "Placeholder desc"
+	desc = "A three-deck research and civilian vessel controlled by the Alliance of Racial Federations."
 
 	scanner_desc = @{"[i]Registration[/i]: ARFS Dallus
-[i]Class[/i]: Placeholder
-[i]Transponder[/i]: Transmitting (CIV), NanoTrasen IFF
-[b]Notice[/b]: NanoTrasen Vessel, authorized personnel only"}
+[i]Class[/i]: Research Frigate, Dallus Class
+[i]Transponder[/i]: Transmitting (CIV), ARF IFF
+[b]Notice[/b]: ARF Vessel, authorized personnel only"}
 
 	icon_state = "ship"
 	vessel_mass = 100000
@@ -241,7 +241,12 @@
 	fore_dir = NORTH	// Which direction the ship/z-level is facing.  It will move dust particles from that direction when moving.
 	base = TRUE		// Honestly unsure what this does but it seems the main sector or "Map" we're at has this so here it stays
 	// The waypoints that are avaliable once you are at this Navpoint
-	initial_generic_waypoints = list("arfs_excursion_hangar")
+	initial_generic_waypoints = list(
+		"arfs_excursion_hangar",
+		"arfs_dock_south", //Deck 3, Port Arm, South Dock
+		"arfs_dock_north", //Deck 3, Port Arm, North Dock
+		"arfs_dock_west"   //Deck 3, Port Arm, West Dock
+		)
 
 	initial_restricted_waypoints = list(
 		"Excursion Shuttle" = list("arfs_excursion_hangar"),

--- a/maps/Arfs/arfs_defines.dm
+++ b/maps/Arfs/arfs_defines.dm
@@ -243,13 +243,13 @@
 	// The waypoints that are avaliable once you are at this Navpoint
 	initial_generic_waypoints = list(
 		"arfs_excursion_hangar",
-		"arfs_dock_south", //Deck 3, Port Arm, South Dock
-		"arfs_dock_north", //Deck 3, Port Arm, North Dock
-		"arfs_dock_west",   //Deck 3, Port Arm, West Dock
-		"arfs_space_nw", //Deck 3, NW space
-		"arfs_space_ne", //Deck 3, NE space
-		"arfs_space_sw", //Deck 3, SW space
-		"arfs_space_se"  //Deck 3, SE space
+		"arfs_dock_south", 		//Deck 3, Port Arm, South Dock
+		"arfs_dock_north", 		//Deck 3, Port Arm, North Dock
+		"arfs_dock_west",   	//Deck 3, Port Arm, West Dock
+		"arfs_space_nw", 		//Deck 3, NW space
+		"arfs_space_ne", 		//Deck 3, NE space
+		"arfs_space_sw", 		//Deck 3, SW space
+		"arfs_space_se"  		//Deck 3, SE space
 		)
 
 	initial_restricted_waypoints = list(

--- a/maps/Arfs/arfs_shuttles.dm
+++ b/maps/Arfs/arfs_shuttles.dm
@@ -318,27 +318,25 @@
 	dock_target_station = "admin_shuttle_dock_airlock"
 	dock_target_offsite = "admin_shuttle_bay"
 
-// Heist
-/datum/shuttle/autodock/multi/skipjack
+// Heist / Skipjack
+/datum/shuttle/autodock/multi/heist
 	name = "Skipjack"
-	warmup_time = 0
-	origin = /area/skipjack_station/start
-	interim = /area/skipjack_station/transit
+	warmup_time = 8
+	move_time = 60
 	can_cloak = TRUE
 	cloaked = TRUE
-	destinations = list(
-		"Fore Starboard Solars" = /area/skipjack_station/northeast_solars,
-		"Fore Port Solars" = /area/skipjack_station/northwest_solars,
-		"Aft Starboard Solars" = /area/skipjack_station/southeast_solars,
-		"Aft Port Solars" = /area/skipjack_station/southwest_solars,
-		"Mining Station" = /area/skipjack_station/mining
+	current_location = "skipjack_base"
+	landmark_transition = "skipjack_transit"
+	shuttle_area = /area/shuttle/skipjack
+	destination_tags = list(
+		"dallus_space_nw"
 		)
+	//docking_controller_tag = ??? doesn't have one?
 	announcer = "Automated Traffic Control"
-
-/datum/shuttle/autodock/multi/skipjack/New()
-	arrival_message = "Attention.  Unidentified object approaching the colony."
-	departure_message = "Attention.  Unidentified object exiting local space.  Unidentified object expected to escape Kara gravity well with current velocity."
-	..()
+	arrival_message = "Attention. An unregistered vessel is approaching Virgo-3B."
+	departure_message = "Attention. A unregistered vessel is now leaving Virgo-3B."
+	defer_initialisation = TRUE
+	move_direction = NORTH
 
 /datum/shuttle/autodock/multi/specops/ert
 	name = "Special Operations"

--- a/maps/Arfs/arfs_shuttles.dm
+++ b/maps/Arfs/arfs_shuttles.dm
@@ -7,7 +7,7 @@
 	warmup_time = 0
 	current_location = "arfs_excursion_hangar"
 	docking_controller_tag = "expshuttle_dock"
-	shuttle_area = list(/area/shuttle/excursion/cockpit, /area/shuttle/excursion/general, /area/shuttle/excursion/cargo, /area/shuttle/excursion/power)
+	shuttle_area = list(/area/shuttle/excursion/cockpit, /area/shuttle/excursion/general, /area/shuttle/excursion/cargo, /area/shuttle/excursion/power, /area/shuttle/excursion/medical)
 	fuel_consumption = 3
 	move_direction = NORTH
 	move_time = 20

--- a/maps/Arfs/arfs_shuttles.dm
+++ b/maps/Arfs/arfs_shuttles.dm
@@ -59,15 +59,19 @@
 	base_area = /area/space
 
 /obj/effect/shuttle_landmark/arfs/deck3/space/sw
+	name = "South West of ARFS Dallus"
 	landmark_tag = "dallus_space_sw"
 
 /obj/effect/shuttle_landmark/arfs/deck3/space/ne
+	name = "North East of ARFS Dallus"
 	landmark_tag = "dallus_space_ne"
 
 /obj/effect/shuttle_landmark/arfs/deck3/space/se
+	name = "South East of ARFS Dallus"
 	landmark_tag = "dallus_space_se"
 
 /obj/effect/shuttle_landmark/arfs/deck3/space/nw
+	name = "North West of ARFS Dallus"
 	landmark_tag = "dallus_space_nw"
 
 //////////////////////////////////////////////////////////////

--- a/maps/Arfs/arfs_shuttles.dm
+++ b/maps/Arfs/arfs_shuttles.dm
@@ -29,11 +29,46 @@
 
 // Exclusive landmark for docking *inside* the station
 /obj/effect/shuttle_landmark/arfs/deck3/excursion
-	name = "A.R.F.S Dallus - Excursion Hanger"
+	name = "A.R.F.S. Dallus - Excursion Hanger"
 	landmark_tag = "arfs_excursion_hangar"
 	docking_controller = "expshuttle_dock"
-	base_turf = /turf/simulated/floor/tiled/techfloor/grid
+	base_turf = /turf/simulated/floor/reinforced
 	base_area = /area/exploration/hanger
+
+/obj/effect/shuttle_landmark/arfs/deck3/dockarm
+	base_turf = /turf/space
+	base_area = /area/space
+
+/obj/effect/shuttle_landmark/arfs/deck3/dockarm/north
+	name = "ARFS Dallus - Docking Arm North"
+	landmark_tag = "arfs_dock_north"
+	docking_controller = "dallus_port_arm_n"
+
+/obj/effect/shuttle_landmark/arfs/deck3/dockarm/south
+	name = "ARFS Dallus - Docking Arm South"
+	landmark_tag = "arfs_dock_south"
+	docking_controller = "dallus_port_arm_s"
+
+/obj/effect/shuttle_landmark/arfs/deck3/dockarm/west
+	name = "ARFS Dallus - Docking Arm West"
+	landmark_tag = "arfs_dock_west"
+	docking_controller = "dallus_port_arm_w"
+
+/obj/effect/shuttle_landmark/arfs/deck3/space
+	base_turf = /turf/space
+	base_area = /area/space
+
+/obj/effect/shuttle_landmark/arfs/deck3/space/sw
+	landmark_tag = "dallus_space_sw"
+
+/obj/effect/shuttle_landmark/arfs/deck3/space/ne
+	landmark_tag = "dallus_space_ne"
+
+/obj/effect/shuttle_landmark/arfs/deck3/space/se
+	landmark_tag = "dallus_space_se"
+
+/obj/effect/shuttle_landmark/arfs/deck3/space/nw
+	landmark_tag = "dallus_space_nw"
 
 //////////////////////////////////////////////////////////////
 // Escape shuttle


### PR DESCRIPTION
Adds a docking arm to D3
Adds four in-space shuttle orbits on D3
Adds a staircase connecting D3 to D2 in the fore hallway
Removes the AFK dorm thing and replaces it with the stairs and a lounge
Adds a huge maintenance expansion around the new dock for mappers to replace when needed
Fixes the explo shuttle dock's base turf
![Salamander Docked](https://i.imgur.com/J7X9ZsL.png)
![Stairs](https://i.imgur.com/41NMnpP.png)