### PR TITLE
Deck 1 & 2 Updates (Autoresleever, construction site, maint expansion, warden fixes, etc)

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -123,7 +123,7 @@
 					GM.adjustBruteLoss(5)
 			else
 				to_chat(user, "<span class='notice'>You need a tighter grip.</span>")
-	
+
 
 /obj/structure/urinal
 	name = "urinal"
@@ -253,7 +253,11 @@
 			var/remove_amount = M.touching.maximum_volume * M.reagent_permeability() //take off your suit first
 			M.touching.remove_any(remove_amount)
 
+/*ARFS Edit
 		M.clean_blood()
+*/
+		M.clean_blood(washshoes=TRUE)
+//End ARFS Edit
 
 	if(isturf(loc))
 		var/turf/tile = loc

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -256,7 +256,7 @@
 /*ARFS Edit
 		M.clean_blood()
 */
-		M.clean_blood(washshoes=TRUE)
+		M.clean_blood(1)
 //End ARFS Edit
 
 	if(isturf(loc))

--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -84732,7 +84732,7 @@ bGs
 bGs
 bGs
 bGs
-bvT
+fhF
 aov
 aaa
 aaa
@@ -84989,7 +84989,7 @@ bGs
 rlZ
 pCz
 bGs
-bvT
+fhF
 aov
 aaa
 aaa
@@ -85246,9 +85246,9 @@ oKe
 ssm
 dar
 bGs
-bvT
-bvT
-bvT
+fhF
+fhF
+fhF
 aaa
 aaa
 aov
@@ -85503,12 +85503,12 @@ bGs
 lCG
 vZI
 bGs
-bvT
-bvT
-bvT
-bvT
-bvT
-bvT
+fhF
+fhF
+fhF
+fhF
+fhF
+fhF
 aov
 aov
 aov
@@ -85758,14 +85758,14 @@ xxh
 iLF
 bGs
 bGs
+bGs
+bGs
 fhF
 fhF
 fhF
 fhF
 fhF
 fhF
-fhF
-bvT
 aaa
 aaa
 aaa
@@ -86022,7 +86022,7 @@ cXo
 oKF
 fYY
 fhF
-bvT
+fhF
 aaa
 aaa
 aaa
@@ -86279,7 +86279,7 @@ pFL
 lST
 rWw
 fhF
-bvT
+fhF
 aaa
 aaa
 aaa
@@ -86536,7 +86536,7 @@ dfZ
 xwb
 bDG
 fhF
-bvT
+fhF
 aaa
 aaa
 aaa
@@ -86793,7 +86793,7 @@ neL
 mEq
 fsL
 fhF
-bvT
+fhF
 aaa
 aaa
 aaa
@@ -87050,7 +87050,7 @@ dic
 fhF
 fhF
 fhF
-bvT
+fhF
 aov
 aov
 aov
@@ -87307,7 +87307,7 @@ eGC
 ssa
 bDH
 shh
-bvT
+shh
 aaa
 aaa
 aaa
@@ -87564,7 +87564,7 @@ jdk
 wox
 bDI
 shh
-bvT
+shh
 aaa
 aaa
 aaa
@@ -87821,7 +87821,7 @@ wQk
 gpp
 bDI
 shh
-bvT
+shh
 aaa
 aaa
 aaa
@@ -88078,7 +88078,7 @@ mHf
 bDq
 bDO
 shh
-bvT
+shh
 aaa
 aaa
 aaa
@@ -88335,7 +88335,7 @@ jJe
 tgg
 xTX
 jJe
-bvT
+jJe
 aaa
 aaa
 aaa
@@ -88592,7 +88592,7 @@ kyQ
 bJd
 uuX
 jJe
-bvT
+jJe
 aov
 aov
 aov
@@ -88849,7 +88849,7 @@ lxn
 siB
 xBc
 jJe
-bvT
+jJe
 aaa
 aaa
 aaa
@@ -89106,7 +89106,7 @@ rRZ
 wHU
 rRZ
 eZa
-bvT
+jJe
 aaa
 aaa
 aaa
@@ -89363,7 +89363,7 @@ kLY
 xXS
 vwr
 eZa
-bvT
+jJe
 aaa
 aaa
 aaa
@@ -89620,7 +89620,7 @@ lAb
 tRx
 rDo
 eZa
-bvT
+jJe
 aaa
 aaa
 aaa

--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -2260,6 +2260,10 @@
 	dir = 5
 	},
 /obj/machinery/camera/autoname,
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "aew" = (
@@ -2301,12 +2305,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "aey" = (
-/obj/machinery/computer/secure_data,
 /obj/machinery/button/remote/blast_door{
 	id = "warden1";
-	name = "Office shutter control";
+	name = "Office Shutters";
 	pixel_x = 22;
-	pixel_y = 10
+	pixel_y = -10
 	},
 /obj/machinery/alarm{
 	pixel_y = 25
@@ -2320,6 +2323,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/machinery/computer/security,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "aez" = (
@@ -3003,15 +3007,14 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "armory";
-	name = "Emergency Access";
-	pixel_x = 22;
-	pixel_y = 30;
-	req_access = list(3)
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "warden_window";
+	name = "Window Shutter";
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -3654,6 +3657,10 @@
 "ahO" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
+	},
+/obj/item/device/radio/intercom/department/security{
+	dir = 4;
+	pixel_x = 20
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -4884,8 +4891,7 @@
 "akv" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/brigdoor/eastleft{
-	name = "Warden's Desk";
-	req_access = list(3)
+	name = "Warden's Desk"
 	},
 /obj/machinery/door/window/brigdoor/eastleft{
 	dir = 8;
@@ -4896,8 +4902,8 @@
 	density = 0;
 	dir = 4;
 	icon_state = "shutter0";
-	id = "warden1";
-	name = "Warden Office Shutters";
+	id = "warden_window";
+	name = "Warden Window Shutter";
 	opacity = 0
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20554,6 +20560,7 @@
 /obj/effect/landmark{
 	name = "JoinLateCryo"
 	},
+/obj/machinery/camera/autoname,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/cryo)
 "aPj" = (
@@ -23419,6 +23426,9 @@
 	tag = "icon-corner_oldtile (NORTHEAST)"
 	},
 /obj/machinery/computer/timeclock/premade/north,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_three)
 "aUc" = (
@@ -41335,7 +41345,7 @@
 "cPE" = (
 /obj/structure/stairs/spawner/west,
 /turf/simulated/floor/tiled/dark,
-/area/engineering/aft_hallway)
+/area/engineering/thrusters)
 "cRw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -42258,12 +42268,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "euX" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/effect/floor_decal/grass_edge/corner{
+/obj/effect/floor_decal/grass_edge{
 	dir = 8
 	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/outdoors/grass/heavy,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/crew_quarters/sleep/cryo)
 "euY" = (
 /obj/structure/flora/pottedplant{
@@ -42521,6 +42530,10 @@
 "eGd" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -44077,10 +44090,13 @@
 /area/engineering/atmos)
 "gBb" = (
 /obj/effect/floor_decal/grass_edge{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/floor_decal/grass_edge,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/grass_edge{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/crew_quarters/sleep/cryo)
 "gBD" = (
 /obj/structure/bed/chair/comfy/brown{
@@ -45318,9 +45334,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_cell_hallway)
 "ieG" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass_engineeringatmos{
+	name = "Engineering";
+	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/foyer)
@@ -45712,6 +45736,13 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"iFB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/foyer)
 "iIi" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/airlock_electronics,
@@ -46345,6 +46376,13 @@
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "armory";
+	name = "Emergency Access";
+	pixel_y = -24;
+	req_access = list(3);
+	pixel_x = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -47399,11 +47437,11 @@
 /turf/simulated/floor/tiled/white,
 /area/engineering/engine_airlock)
 "kMC" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/effect/floor_decal/grass_edge/corner{
+/obj/effect/floor_decal/grass_edge{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/heavy,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/crew_quarters/sleep/cryo)
 "kNk" = (
 /turf/simulated/floor/greengrid/nitrogen,
@@ -48462,6 +48500,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/gravity)
+"mty" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/foyer)
 "mtG" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_medical{
@@ -48951,6 +49001,11 @@
 	dir = 6
 	},
 /obj/machinery/mech_recharger,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "mTb" = (
@@ -50429,6 +50484,10 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "oPj" = (
@@ -50454,12 +50513,8 @@
 /area/engineering/break_room)
 "oPH" = (
 /obj/structure/ghost_pod/ghost_activated/pokemon,
-/obj/effect/floor_decal/grass_edge,
-/obj/effect/floor_decal/grass_edge{
-	dir = 4
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/outdoors/grass/heavy,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/crew_quarters/sleep/cryo)
 "oQk" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -51023,6 +51078,12 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_monitoring)
+"pCt" = (
+/obj/effect/floor_decal/grass_edge{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/cryo)
 "pCu" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -51102,7 +51163,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
-/area/engineering/aft_hallway)
+/area/engineering/thrusters)
 "pGF" = (
 /obj/structure/table/standard,
 /obj/item/stack/medical/advanced/bruise_pack,
@@ -55450,6 +55511,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"uZw" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/grass_edge,
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/cryo)
 "uZI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55464,7 +55530,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/engineering/aft_hallway)
+/area/engineering/thrusters)
 "vbG" = (
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
@@ -89779,7 +89845,7 @@ bAQ
 mOU
 bAQ
 bxX
-ieG
+ipf
 bze
 bAe
 bAW
@@ -90032,13 +90098,13 @@ aWj
 bBr
 wBc
 shV
-shV
+mty
 hLX
 shV
 byr
-shV
+ieG
 kAh
-bAe
+iFB
 bAX
 jco
 rPw
@@ -90293,7 +90359,7 @@ vxC
 mdy
 bxk
 ttb
-bxk
+ipf
 bzv
 bAe
 bAX
@@ -90741,7 +90807,7 @@ aRA
 aRq
 aSH
 aTm
-aTm
+pCt
 aTk
 aQz
 aTV
@@ -90997,7 +91063,7 @@ aRr
 aRA
 aTm
 aRA
-aSB
+uZw
 gBb
 euX
 aQz

--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -22525,7 +22525,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/cryo)
 "aSB" = (
-/obj/machinery/hologram/holopad,
+/obj/effect/landmark{
+	name = "JoinLateGateway"
+	},
+/obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/cryo)
 "aSC" = (
@@ -22549,6 +22552,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/cryo)
 "aSF" = (
@@ -22807,12 +22811,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_four)
 "aTe" = (
-/obj/structure/table/reinforced,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
 /obj/effect/floor_decal/grass_edge,
+/obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/cryo)
 "aTf" = (
@@ -47441,6 +47441,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/grass,
 /area/crew_quarters/sleep/cryo)
 "kNk" = (
@@ -55512,7 +55513,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "uZw" = (
-/obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/grass_edge,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/cryo)
@@ -88749,7 +88749,7 @@ aQz
 aPh
 aTm
 aQJ
-aSB
+aTm
 aQJ
 aTm
 aSg
@@ -91319,7 +91319,7 @@ aQz
 aRq
 aSb
 aRq
-aRA
+aSB
 aTe
 kMC
 oPH

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -6437,14 +6437,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "amT" = (
-/obj/effect/floor_decal/corner_oldtile/purple{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/exploration/hallway)
+/turf/simulated/floor/plating,
+/area/space)
 "amU" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -6849,12 +6847,11 @@
 	name = "\improper Research Breakroom"
 	})
 "anN" = (
-/obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
+/area/hallway/primary/deckthree/fore)
 "anO" = (
 /obj/structure/railing{
 	dir = 4
@@ -11145,7 +11142,7 @@
 	name = "Fore Hallway - Deck 2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -19087,7 +19084,9 @@
 	})
 "aLG" = (
 /obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "aLH" = (
@@ -21042,7 +21041,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aQw" = (
@@ -21992,7 +21993,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -22637,9 +22638,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
 "aUo" = (
-/obj/random/maintenance/engineering,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
-/area/construction)
+/area/space)
 "aUq" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance,
@@ -23971,11 +23972,6 @@
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/pathfinder_office)
-"aXv" = (
-/obj/effect/floor_decal/rust,
-/obj/item/clothing/under/suit_jacket/gambler,
-/turf/simulated/floor/plating,
-/area/space)
 "aXw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -24508,20 +24504,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aYN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aYO" = (
@@ -25275,6 +25258,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"baJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "baO" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -25283,6 +25273,16 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"bbd" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 1;
+	tag = "icon-bordercolorcorner (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "bcc" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -25301,6 +25301,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hallway)
+"bgz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "bgY" = (
 /obj/machinery/alarm{
 	frequency = 1441;
@@ -25343,21 +25350,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
 "blM" = (
-/obj/random/junk,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/construction)
+/area/space)
 "bmh" = (
 /obj/machinery/atmospherics/portables_connector/fuel{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/exploration/hanger)
-"boH" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "boS" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
@@ -25381,13 +25382,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
-"bsn" = (
-/obj/structure/table/rack/steel,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/space)
 "bsG" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/carpet,
@@ -25396,10 +25390,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"buO" = (
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/space)
 "bxM" = (
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
@@ -25453,12 +25443,13 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"bGS" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
+"bGW" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
+/area/gateway)
 "bJT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -25556,9 +25547,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
 "cbP" = (
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/engineering)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "ccC" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -25602,6 +25603,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_w)
+"ciO" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "cln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 1
@@ -25637,11 +25642,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"crC" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/borderfloorblack,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "cvJ" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -25678,6 +25678,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_n)
+"cAG" = (
+/obj/fiftyspawner/steel,
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/plating,
+/area/construction)
 "cBR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -25702,6 +25710,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall_starboard)
+"cCT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "cEw" = (
 /obj/random/junk,
 /obj/structure/table/rack,
@@ -25709,6 +25724,15 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"cEV" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "cFi" = (
 /turf/simulated/wall,
 /area/security/checkpoint/starboard)
@@ -25728,32 +25752,6 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"cJe" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass{
-	name = "Fore Hallway - Deck 2"
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
-"cKb" = (
-/obj/effect/floor_decal/borderfloorblack/corner,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
-"cLv" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
 "cMy" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -25787,15 +25785,6 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_w)
-"cOT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
 "cPi" = (
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
@@ -25813,6 +25802,12 @@
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
+"cRI" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "cTt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -25848,12 +25843,6 @@
 /obj/effect/shuttle_landmark/arfs/deck3/dockarm/south/starboard,
 /turf/space,
 /area/space)
-"cYt" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
 "dax" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25884,10 +25873,6 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
-"deI" = (
-/obj/structure/barricade/planks,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay_aft)
 "dfo" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -25907,29 +25892,27 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay/autoresleever)
-"dhZ" = (
-/obj/fiftyspawner/plastic,
-/obj/structure/closet/crate{
-	dir = 2
+"dhb" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
 	},
-/obj/fiftyspawner/plastic,
-/turf/simulated/floor/plating,
-/area/construction)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "djz" = (
 /turf/simulated/floor/plating,
 /area/construction)
 "dkj" = (
 /turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
+"dkx" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/space)
 "doV" = (
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engineering)
-"doZ" = (
-/obj/effect/floor_decal/borderfloorblack/corner,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "dpy" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -25938,15 +25921,9 @@
 /area/construction)
 "dqf" = (
 /obj/structure/table/reinforced,
-/obj/random/maintenance/foodstuff,
+/obj/random/contraband,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"dtn" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "dtu" = (
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
@@ -25954,28 +25931,44 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"dvO" = (
-/obj/item/weapon/rcd,
-/obj/structure/closet/crate{
-	dir = 2
+"dwC" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
 	},
-/obj/random/tool,
-/obj/random/tool,
-/obj/random/tool,
-/obj/random/tool,
-/obj/random/toolbox,
-/turf/simulated/floor/plating,
-/area/construction)
-"dyd" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/construction)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"dAn" = (
+/obj/structure/sign/directions/science{
+	pixel_y = -5
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = -12
+	},
+/turf/simulated/wall,
+/area/hallway/primary/deckthree/central)
 "dBB" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/space)
+"dIB" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_external/public{
+	name = "Docking Arm"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"dIS" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "dKe" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -25999,12 +25992,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
-"dNb" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
 "dNc" = (
 /obj/structure/bed/chair/bay,
 /turf/simulated/floor/carpet,
@@ -26050,6 +26037,11 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engineering)
+"dTL" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/space)
 "dVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
@@ -26061,12 +26053,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"dYp" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "dZs" = (
 /obj/structure/bed/chair/bay/comfy,
 /turf/simulated/floor/plating,
@@ -26169,19 +26155,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall)
+"ekI" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "elk" = (
 /turf/simulated/wall,
 /area/hallway/station/docking_hall_starboard)
-"elD" = (
-/obj/structure/sign/directions/science{
-	pixel_y = -5
-	},
-/obj/structure/sign/directions/evac{
-	dir = 4;
-	pixel_y = -12
-	},
-/turf/simulated/wall,
-/area/hallway/primary/deckthree/central)
 "emY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -26236,6 +26216,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"etF" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "eug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
@@ -26298,26 +26288,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"eFT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
 "eGa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -26327,18 +26297,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"eJi" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "eJw" = (
-/obj/fiftyspawner/glass,
-/obj/structure/closet/crate{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
+"eJV" = (
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/fiftyspawner/glass,
-/turf/simulated/floor/plating,
-/area/construction)
-"eJV" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/space)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "eKj" = (
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/dark,
@@ -26359,14 +26343,6 @@
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
-"eNG" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_external/public{
-	name = "Docking Arm"
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
 "ePN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -26393,25 +26369,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"eQs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
-"eQv" = (
-/obj/fiftyspawner/rods,
-/obj/structure/closet/crate{
-	dir = 2
-	},
-/obj/fiftyspawner/rods,
-/turf/simulated/floor/plating,
-/area/construction)
-"eQK" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/space)
 "eRl" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -26422,9 +26379,7 @@
 /area/hallway/station/docking_hall_starboard)
 "eSR" = (
 /obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "eUF" = (
@@ -26452,6 +26407,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"eVI" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "eWg" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -26513,23 +26480,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
-"feE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "feL" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 9
@@ -26594,19 +26544,12 @@
 /obj/structure/bed/chair/bay,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
-"fmT" = (
-/obj/effect/floor_decal/corner_oldtile/purple{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+"fnE" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/exploration/hallway)
+/area/hallway/station/docking_hall)
 "fot" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -26616,21 +26559,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
-"fqu" = (
-/obj/effect/floor_decal/corner_oldtile/purple{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+"fpx" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/exploration/hallway)
+/area/hallway/station/docking_hall_starboard)
 "frr" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/engineering)
+"fsb" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"ftm" = (
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/space)
 "ftC" = (
 /obj/machinery/light{
 	dir = 4
@@ -26643,6 +26595,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"ftH" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "fwq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26717,6 +26674,13 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"fFi" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/gateway)
 "fFt" = (
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -26736,13 +26700,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall_starboard)
-"fLC" = (
-/obj/machinery/door/firedoor/glass,
+"fIt" = (
+/obj/fiftyspawner/plastic,
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/fiftyspawner/plastic,
+/turf/simulated/floor/plating,
+/area/construction)
+"fML" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"fPi" = (
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
+/area/hallway/station/docking_hall)
 "fQO" = (
 /obj/effect/floor_decal/corner_kafel/blue{
 	dir = 5;
@@ -26792,10 +26774,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
-"gcY" = (
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/space)
+"geO" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "gfR" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -26813,6 +26798,19 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"giK" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "gkm" = (
 /obj/structure/table/rack/steel,
 /obj/random/maintenance/clean,
@@ -26849,6 +26847,22 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"guB" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"gyO" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Fore Hallway - Deck 2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "gzO" = (
 /obj/machinery/vending/tool,
 /turf/simulated/floor/tiled/dark,
@@ -26900,10 +26914,10 @@
 /area/hallway/station/docking_hall)
 "gGb" = (
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
+/area/hallway/primary/deckthree/fore)
 "gHu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26969,12 +26983,6 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"gTC" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
 "gTR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -27090,26 +27098,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall_starboard)
-"hpH" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "hqF" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -27170,6 +27158,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"hCz" = (
+/obj/fiftyspawner/glass,
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/fiftyspawner/glass,
+/turf/simulated/floor/plating,
+/area/construction)
 "hCG" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -27185,15 +27181,11 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_s)
-"hEp" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
+"hDL" = (
+/obj/effect/floor_decal/rust,
+/obj/item/clothing/head/collectable/petehat,
+/turf/simulated/floor/plating,
+/area/space)
 "hFL" = (
 /obj/random/pottedplant,
 /obj/machinery/firealarm{
@@ -27227,12 +27219,6 @@
 /obj/random/pottedplant,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
-"hGc" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "hGQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -27303,6 +27289,12 @@
 /obj/effect/shuttle_landmark/arfs/deck3/dockarm/north/starboard,
 /turf/space,
 /area/space)
+"hTm" = (
+/obj/machinery/light/floortube{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "hTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27373,12 +27365,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"idR" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/construction)
 "ihu" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -27405,14 +27391,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"ilZ" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/space)
 "inm" = (
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay_aft)
-"ipT" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/random/contraband,
-/obj/random/contraband,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
 "iuR" = (
@@ -27471,6 +27456,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"iwi" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "iwz" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window{
@@ -27544,13 +27535,32 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"iFC" = (
-/obj/structure/sign/directions/medical{
-	pixel_y = 6
+"iAN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/sign/directions/engineering,
-/turf/simulated/wall,
-/area/hallway/primary/deckthree/central)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"iFy" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "iGa" = (
 /obj/machinery/door/airlock/angled_tgmc{
 	dir = 4;
@@ -27565,19 +27575,27 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"iKF" = (
-/obj/structure/table/reinforced,
-/obj/random/contraband,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay_aft)
+"iKQ" = (
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Patient Room A";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_kafel/blue/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "iLs" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/engineering)
-"iMk" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 6
-	},
+"iMf" = (
+/obj/effect/floor_decal/rust,
+/obj/item/clothing/mask/mouthwheat,
+/turf/simulated/floor/plating,
+/area/space)
+"iMp" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "iNh" = (
@@ -27592,22 +27610,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
-"iNC" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass{
-	name = "Fore Hallway - Deck 2"
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
-"iOC" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -27637,6 +27639,15 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall)
+"iVf" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/gateway)
 "iWt" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -27674,18 +27685,15 @@
 /obj/effect/floor_decal/corner/purple/bordercorner,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
-"jjp" = (
-/obj/random/maintenance/clean,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "jmh" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"jmT" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/space)
 "jnM" = (
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
@@ -27713,12 +27721,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/primary/deckthree/aft)
-"jpF" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "jpN" = (
 /obj/machinery/light,
 /obj/effect/map_helper/airlock/sensor/int_sensor,
@@ -27735,13 +27737,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"jtf" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass{
-	name = "Fore Stairway"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
 "jud" = (
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
@@ -27867,15 +27862,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"jKy" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay_aft)
 "jLU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -27890,6 +27876,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"jOV" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "jQv" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance,
@@ -27928,20 +27920,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"jZP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/exploration/hallway)
 "kaU" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
@@ -27986,6 +27964,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"kkY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "knz" = (
 /obj/random/maintenance/engineering,
 /obj/effect/floor_decal/rust,
@@ -28000,12 +27995,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
-"kpu" = (
-/obj/effect/floor_decal/borderfloorblack{
+"kpO" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
+/area/hallway/station/docking_hall_starboard)
 "kql" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28068,17 +28063,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
-"kzK" = (
-/obj/effect/floor_decal/borderfloorblack{
+"kCb" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
-"kCy" = (
-/obj/effect/floor_decal/rust,
-/obj/item/clothing/head/collectable/petehat,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/medbay_aft)
 "kDP" = (
 /obj/structure/closet/crate{
 	dir = 2
@@ -28121,12 +28116,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
-"kMg" = (
-/obj/machinery/light/floortube{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/construction)
 "kME" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28159,36 +28148,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"kZT" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -25
-	},
-/turf/simulated/floor/tiled/dark,
-/area/gateway)
-"laI" = (
-/obj/structure/closet/crate{
-	dir = 2
-	},
-/obj/item/weapon/pipe_dispenser,
-/obj/random/tool,
-/obj/random/tool,
-/obj/random/tool,
-/obj/random/tool,
-/obj/random/toolbox,
-/turf/simulated/floor/plating,
-/area/construction)
-"lch" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
 "lcT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/firealarm{
@@ -28229,13 +28188,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall_starboard)
-"lma" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+"lmP" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Fore Stairway"
 	},
-/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
+/area/hallway/primary/deckthree/fore)
 "lnC" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -28252,12 +28211,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"loQ" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "ltj" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -28352,12 +28305,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"lId" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "lJu" = (
 /obj/effect/floor_decal/corner_kafel/blue/full{
 	dir = 4
@@ -28373,16 +28320,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay/autoresleever)
-"lNg" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 1;
-	tag = "icon-bordercolorcorner (EAST)"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
 "lOs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28404,6 +28341,12 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"lPs" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "lSR" = (
 /obj/effect/floor_decal/corner_kafel/blue/full{
 	dir = 1
@@ -28433,6 +28376,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/engineering)
+"lXL" = (
+/obj/fiftyspawner/rods,
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/fiftyspawner/rods,
+/turf/simulated/floor/plating,
+/area/construction)
 "mde" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28478,6 +28429,45 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"miC" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"miF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
+"mjK" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_external/public{
+	name = "Docking Arm"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "mkX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -28543,6 +28533,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/engineering)
+"mqP" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "msj" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -28552,17 +28552,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
-"msF" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay_aft)
+"mtn" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "mvu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -28620,6 +28613,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"mEA" = (
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/item/weapon/pipe_dispenser,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/construction)
 "mER" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 6
@@ -28695,6 +28700,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_n)
+"mOc" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "mRx" = (
 /obj/machinery/light{
 	dir = 8
@@ -28720,22 +28731,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_airlock_w)
-"mTE" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
 "mUq" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall_starboard_airlock_s)
-"mYR" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "nao" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark,
@@ -28760,11 +28759,6 @@
 "ney" = (
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
-"neC" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/space)
 "ngC" = (
 /obj/random/trash,
 /obj/machinery/floodlight{
@@ -28807,6 +28801,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/medbay_aft)
+"nwv" = (
+/obj/machinery/light/floortube{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "nwy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -28889,9 +28889,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Docking Arm"
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "nJm" = (
@@ -28963,6 +28961,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"nQF" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/space)
+"nQP" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "nWL" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29031,6 +29043,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"okT" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/construction)
 "olY" = (
 /obj/effect/floor_decal/corner_kafel/blue/full{
 	dir = 8
@@ -29047,6 +29063,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"ool" = (
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 6;
+	tag = "icon-corner_kafel (SOUTHEAST)"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "oon" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -29070,19 +29096,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard_airlock_n)
-"ooX" = (
-/obj/effect/floor_decal/corner_oldtile/purple{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/exploration/hallway)
 "oqc" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -29117,19 +29130,6 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"ous" = (
-/obj/effect/floor_decal/rust,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/space)
-"ouw" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_external/public{
-	name = "Docking Arm"
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "ouH" = (
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/tiled/techfloor,
@@ -29146,6 +29146,12 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"ovP" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "oym" = (
 /obj/random/maintenance/clean,
 /obj/structure/table/rack,
@@ -29178,15 +29184,6 @@
 "oHr" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood,
-/area/space)
-"oIc" = (
-/obj/machinery/light/floortube,
-/turf/simulated/floor/plating,
-/area/construction)
-"oIZ" = (
-/obj/effect/floor_decal/rust,
-/obj/item/clothing/mask/mouthwheat,
-/turf/simulated/floor/plating,
 /area/space)
 "oJO" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -29221,29 +29218,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
-"oOY" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
-/area/space)
 "oVj" = (
 /obj/structure/filingcabinet/security,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"oXL" = (
+/obj/machinery/light/floortube{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "oXR" = (
 /obj/random/maintenance/clean,
 /obj/structure/table/rack,
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"oYz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark,
-/area/gateway)
 "paK" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -29293,27 +29283,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "phi" = (
-/obj/effect/floor_decal/borderfloorblack,
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
-"pjU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack/corner,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "pjZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
@@ -29326,6 +29301,13 @@
 "plb" = (
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engineering)
+"plc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "plU" = (
 /obj/structure/grille/broken,
 /obj/item/weapon/tool/wirecutters,
@@ -29335,12 +29317,17 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"poS" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+"pmw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
+/area/hallway/primary/deckthree/central)
 "ppc" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -29354,12 +29341,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
-"pqK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/construction)
 "prE" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/deckthree/central)
@@ -29430,12 +29411,22 @@
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
-"pCY" = (
+"pEl" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/space)
+"pEz" = (
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 5
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
+/area/hallway/primary/deckthree/aft)
 "pFn" = (
 /obj/structure/table/rack/steel,
 /obj/structure/catwalk,
@@ -29453,25 +29444,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
-"pGX" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
-"pIU" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner_kafel/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"pJy" = (
-/obj/machinery/light/floortube{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/construction)
 "pKZ" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
@@ -29482,13 +29454,6 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"pMX" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
 "pND" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -29551,6 +29516,10 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_n)
+"qaW" = (
+/obj/structure/barricade/planks,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "qbw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorblack{
@@ -29579,16 +29548,48 @@
 "qhe" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
-"qin" = (
+"qhA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
+/area/hallway/primary/deckthree/central)
+"qhT" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "qiG" = (
 /obj/effect/shuttle_landmark/arfs/deck3/space/ne,
 /turf/space,
 /area/space)
+"qks" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "qkB" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -29655,15 +29656,30 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
-"qsl" = (
-/obj/machinery/light/floortube{
-	dir = 4
-	},
+"qqd" = (
+/obj/machinery/light/floortube,
 /turf/simulated/floor/plating,
 /area/construction)
+"qrQ" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Fore Hallway - Deck 2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "qsL" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/engineering)
+"qxb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "qxq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -29733,6 +29749,15 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay/autoresleever)
+"qBJ" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "qDI" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -29749,13 +29774,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
-"qEh" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "qGg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29788,14 +29806,6 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
-"qIK" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/table/rack/steel,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/space)
 "qJt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29826,9 +29836,7 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Docking Arm"
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "qSk" = (
@@ -29869,12 +29877,11 @@
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
-"qZQ" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 10
-	},
+"qXF" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
+/area/hallway/primary/deckthree/central)
 "rbX" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -29893,6 +29900,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall)
+"rfr" = (
+/obj/structure/frame,
+/turf/simulated/floor/plating,
+/area/construction)
 "rgd" = (
 /obj/machinery/alarm{
 	frequency = 1441;
@@ -29903,6 +29914,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"rhB" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "rhZ" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -29936,16 +29951,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
-"rnz" = (
-/obj/effect/floor_decal/corner_oldtile/purple{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/exploration/hallway)
 "rnI" = (
 /obj/effect/shuttle_landmark/arfs/deck3/dockarm/north,
 /turf/space,
@@ -29972,19 +29977,36 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"roZ" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/construction)
 "rqW" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
-"rrr" = (
-/obj/effect/floor_decal/borderfloorblack,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "rsg" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
+"rtN" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/space)
+"rvM" = (
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/space)
+"rwQ" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/space)
+"ryT" = (
+/obj/structure/table/reinforced,
+/obj/random/maintenance/foodstuff,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "rzp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -30003,10 +30025,31 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"rBH" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
+"rFg" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
+"rGA" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "rGF" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"rHd" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
 "rJo" = (
 /obj/machinery/alarm{
 	frequency = 1441;
@@ -30022,10 +30065,9 @@
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engineering)
 "rNP" = (
-/obj/effect/floor_decal/rust,
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/space)
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "rSR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30069,10 +30111,6 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"rVh" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/space)
 "rVI" = (
 /obj/machinery/vending/loadout/uniform,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -30097,6 +30135,11 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"saB" = (
+/obj/effect/floor_decal/rust,
+/obj/item/clothing/under/suit_jacket/gambler,
+/turf/simulated/floor/plating,
+/area/space)
 "sfJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -30111,6 +30154,19 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall_airlock_w)
+"siL" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
+"sjK" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "skg" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
@@ -30136,6 +30192,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"spW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "sqZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
@@ -30174,12 +30247,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_airlock_s)
-"sKe" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "sQD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -30222,17 +30289,19 @@
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
-"sXA" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"sXf" = (
+/obj/structure/sign/directions/medical{
+	pixel_y = 6
 	},
-/obj/effect/floor_decal/borderfloorblack/corner{
+/obj/structure/sign/directions/engineering,
+/turf/simulated/wall,
+/area/hallway/primary/deckthree/central)
+"sXy" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
+/turf/simulated/floor/plating,
+/area/construction)
 "sYs" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
@@ -30353,6 +30422,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"tnW" = (
+/obj/item/frame,
+/turf/simulated/floor/plating,
+/area/construction)
 "txY" = (
 /obj/structure/table/rack/steel,
 /obj/random/maintenance/clean,
@@ -30367,20 +30440,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
-"tBy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "tFQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30447,6 +30506,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"tRt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "tSZ" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -30536,21 +30602,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"ucK" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
-"udb" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
 "udK" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorblack{
@@ -30561,6 +30612,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"uhE" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "uhG" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -30598,16 +30654,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/medical/medbay2)
-"ukG" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Patient Room A";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_kafel/blue/full{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "unD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/plating,
@@ -30637,6 +30683,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay/autoresleever)
+"uql" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/construction)
+"urL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "uuA" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass{
@@ -30655,15 +30722,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"uxv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "uzq" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_engineeringatmos{
@@ -30694,16 +30752,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_airlock_n)
-"uFe" = (
-/obj/effect/floor_decal/corner_kafel/blue{
-	dir = 6;
-	tag = "icon-corner_kafel (SOUTHEAST)"
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "uGe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -30732,10 +30780,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"uLa" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/engineering)
+"uPZ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "uQc" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate{
@@ -30743,23 +30793,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"uQM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "uQO" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash_pile,
@@ -30786,6 +30819,30 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"uTT" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
+"uUH" = (
+/obj/random/maintenance/clean,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "uXm" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/yellow/border,
@@ -30803,27 +30860,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
-"vhm" = (
-/obj/effect/floor_decal/rust,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "vlu" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"vno" = (
-/obj/effect/floor_decal/borderfloorblack/corner,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
-"vnM" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "vpj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -30834,6 +30874,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"vpA" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "vrt" = (
@@ -30879,7 +30925,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/fore)
+/area/hallway/primary/deckthree/central)
 "vyJ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
@@ -30898,10 +30944,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
-"vBA" = (
-/obj/effect/floor_decal/borderfloorblack/corner,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "vCb" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -30932,15 +30974,19 @@
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
-"vEY" = (
-/obj/structure/frame,
-/turf/simulated/floor/plating,
-/area/construction)
 "vHH" = (
 /obj/random/trash_pile,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"vJM" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Fore Hallway - Deck 2"
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "vMZ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
@@ -30960,6 +31006,12 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"vTK" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "vVq" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -31003,16 +31055,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
-"vYc" = (
-/obj/effect/floor_decal/corner_oldtile/purple{
-	dir = 6
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/exploration/hallway)
 "vZg" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -31084,6 +31126,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"wlz" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "wlA" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
@@ -31096,13 +31144,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/exploration/hanger)
-"woR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall_starboard)
 "wpd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31184,6 +31225,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"wEQ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "wFO" = (
 /obj/machinery/light,
 /obj/effect/map_helper/airlock/sensor/int_sensor,
@@ -31212,14 +31259,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"wJd" = (
-/obj/fiftyspawner/steel,
-/obj/structure/closet/crate{
-	dir = 1
-	},
-/obj/fiftyspawner/steel,
-/turf/simulated/floor/plating,
-/area/construction)
 "wJu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -31305,6 +31344,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/station/micro)
+"xgv" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "xih" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -31331,6 +31376,12 @@
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"xlh" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "xmD" = (
 /obj/machinery/light{
 	dir = 4
@@ -31347,47 +31398,11 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
-"xrM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
-"xwk" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
 "xxE" = (
 /obj/machinery/door/window{
 	dir = 2
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/station/docking_hall)
-"xAr" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass{
-	name = "Fore Hallway - Deck 2"
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "xBS" = (
 /obj/machinery/power/apc{
@@ -31421,13 +31436,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
-"xHi" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/gateway)
 "xHV" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 20
@@ -31466,6 +31474,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"xLO" = (
+/obj/item/weapon/rcd,
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/construction)
 "xNH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31488,10 +31508,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall_airlock_n)
-"xOV" = (
-/obj/item/frame,
-/turf/simulated/floor/plating,
-/area/construction)
 "xPf" = (
 /obj/machinery/vending/snack{
 	dir = 1
@@ -31501,16 +31517,6 @@
 "xPn" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard_airlock_n)
-"xPF" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/construction)
-"xRo" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/space)
 "xSR" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31523,18 +31529,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
-"xWC" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/borderfloorblack,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
-"xWS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/station/docking_hall)
 "xXw" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -31554,6 +31548,19 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"yaF" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "ybj" = (
 /obj/random/trash_pile,
 /obj/structure/catwalk,
@@ -31565,9 +31572,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"yht" = (
+"ycJ" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/contraband,
+/obj/random/contraband,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"yfo" = (
+/obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 6
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"ygn" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
@@ -47369,7 +47389,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -47626,7 +47646,7 @@ aaa
 aaa
 aaa
 vCT
-gGb
+fPi
 hBT
 wag
 vCT
@@ -47883,7 +47903,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -48140,7 +48160,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -48399,7 +48419,7 @@ aaa
 eUF
 cTt
 tdW
-lma
+qxb
 eUF
 aaa
 aaa
@@ -48654,7 +48674,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -48911,7 +48931,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 ebl
 jnM
 eUF
@@ -49168,9 +49188,9 @@ aaa
 aaa
 aaa
 vCT
-pMX
-hnN
 aLG
+hnN
+uhE
 vCT
 aaa
 aaa
@@ -49425,7 +49445,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -50453,7 +50473,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -51738,7 +51758,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 mnQ
 eUF
@@ -52252,7 +52272,7 @@ aaa
 aaa
 aaa
 eUF
-xWS
+plc
 tdW
 xjs
 eUF
@@ -52766,7 +52786,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -53023,9 +53043,9 @@ aaa
 aaa
 aaa
 vCT
-pMX
-hnN
 aLG
+hnN
+uhE
 vCT
 aaa
 aaa
@@ -53280,7 +53300,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -53537,7 +53557,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -54051,7 +54071,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 ebl
 jnM
 eUF
@@ -54096,7 +54116,7 @@ aaa
 akL
 aqQ
 avA
-xwk
+uTT
 app
 app
 app
@@ -54308,7 +54328,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -54351,14 +54371,14 @@ aaa
 aaa
 aaa
 akL
-dYp
+xlh
 arb
-uQM
+kkY
 ann
 asz
-mYR
-mYR
-uxv
+rGA
+rGA
+aQu
 prE
 ajm
 ajm
@@ -54565,7 +54585,7 @@ aaa
 aaa
 aaa
 vCT
-gGb
+fPi
 hBT
 wag
 vCT
@@ -54608,14 +54628,14 @@ akL
 akL
 akL
 akL
-dYp
+xlh
 arb
 ajj
 aUl
 akj
 aUl
 aUl
-aQu
+tRt
 afV
 inm
 aRn
@@ -54638,7 +54658,7 @@ eus
 aZu
 aZu
 cVW
-deI
+qaW
 uSA
 njQ
 uby
@@ -54822,7 +54842,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -54857,15 +54877,15 @@ aTy
 amY
 afV
 amP
-mYR
-mYR
-mYR
-mYR
+rGA
+rGA
+rGA
+rGA
 ann
-mYR
-mYR
-mYR
-jpF
+rGA
+rGA
+rGA
+mOc
 arb
 ajj
 aUl
@@ -55079,7 +55099,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -55113,7 +55133,7 @@ aWY
 art
 aGg
 aqu
-tBy
+qhA
 aVJ
 aDq
 aDq
@@ -55370,22 +55390,22 @@ axY
 amY
 amY
 afV
-dYp
-pjU
-boH
-boH
-boH
-boH
-boH
-boH
-boH
-boH
+xlh
+qks
+vyc
+vyc
+vyc
+vyc
+vyc
+vyc
+vyc
+vyc
 aXx
-boH
-boH
-boH
+vyc
+vyc
+vyc
 aRI
-boH
+vyc
 auh
 afV
 aZu
@@ -55627,7 +55647,7 @@ auS
 amY
 avY
 afV
-dYp
+xlh
 aOL
 aUe
 aUe
@@ -55850,7 +55870,7 @@ aaa
 aaa
 aaa
 eUF
-gGb
+fPi
 hBT
 jnM
 eUF
@@ -56107,7 +56127,7 @@ aaa
 aaa
 aaa
 vCT
-gGb
+fPi
 hBT
 jnM
 vCT
@@ -56364,9 +56384,9 @@ vCT
 vCT
 vCT
 vCT
-nHZ
+dIB
 uRI
-eNG
+nHZ
 vCT
 vCT
 vCT
@@ -56398,7 +56418,7 @@ akt
 aSH
 akt
 aqd
-dYp
+xlh
 aOL
 ams
 als
@@ -56620,11 +56640,11 @@ axn
 bXQ
 mDx
 gEp
-gTC
-bGS
+dwC
+jOV
 hBT
-cYt
-qZQ
+fnE
+ovP
 gEp
 pNS
 bXQ
@@ -56655,7 +56675,7 @@ akt
 aSH
 akt
 aqd
-dYp
+xlh
 aOL
 aUe
 aKy
@@ -56877,7 +56897,7 @@ avy
 bXQ
 tUz
 dtu
-gGb
+fPi
 exg
 tdW
 vgI
@@ -56912,7 +56932,7 @@ aRc
 aRc
 aRc
 aqd
-anN
+rFg
 alm
 alp
 alw
@@ -57134,7 +57154,7 @@ acD
 bXQ
 dNc
 dtu
-gGb
+fPi
 nMT
 pNL
 tgK
@@ -57391,7 +57411,7 @@ aWd
 bXQ
 grV
 dtu
-gGb
+fPi
 rbX
 eje
 eYL
@@ -57426,7 +57446,7 @@ aRc
 awO
 aRc
 aqd
-dYp
+xlh
 alt
 ams
 axf
@@ -57648,7 +57668,7 @@ aNF
 qOs
 dtu
 dtu
-gGb
+fPi
 cbz
 chi
 xxE
@@ -57683,7 +57703,7 @@ akt
 aIz
 akt
 aqd
-dYp
+xlh
 alt
 ams
 aly
@@ -57905,7 +57925,7 @@ rhZ
 bXQ
 wKh
 dtu
-gGb
+fPi
 iUf
 cMy
 nyd
@@ -58162,7 +58182,7 @@ eNy
 bXQ
 dNc
 dtu
-gGb
+fPi
 vVq
 pNL
 vVq
@@ -58197,7 +58217,7 @@ akt
 aHg
 avl
 aRf
-dYp
+xlh
 alt
 afV
 ahH
@@ -58264,7 +58284,7 @@ pmr
 rUU
 fFt
 aAH
-fFt
+sjK
 ath
 pvJ
 tIs
@@ -58419,7 +58439,7 @@ lVr
 bXQ
 tUz
 dtu
-gGb
+fPi
 exg
 xXw
 vgI
@@ -58519,14 +58539,14 @@ fFt
 ath
 euS
 euS
-euS
+ciO
 euS
 fFt
 ath
 fFt
 aDJ
 ajC
-euS
+ciO
 fFt
 qsL
 qsL
@@ -58679,8 +58699,8 @@ dtu
 hFS
 lyc
 kva
-cKb
-iMk
+iMp
+wEQ
 dtu
 iOU
 bXQ
@@ -58739,10 +58759,10 @@ aEk
 aEk
 aEk
 mpv
-uFe
+ool
 axu
 aYb
-pIU
+baJ
 aqm
 aLb
 anx
@@ -58772,7 +58792,7 @@ euS
 fFt
 ath
 euS
-ajC
+ftH
 ajC
 ajC
 fFt
@@ -58782,10 +58802,10 @@ euS
 mTh
 euS
 frr
-frr
+geO
 frr
 euS
-ajC
+ftH
 aAH
 jmh
 qsL
@@ -58936,7 +58956,7 @@ syU
 gIE
 bVN
 uRI
-xAr
+vJM
 bXQ
 bXQ
 bXQ
@@ -59016,8 +59036,8 @@ uby
 mzZ
 aqa
 aqa
-dqf
-dqf
+ryT
+ryT
 kYg
 aqa
 aqa
@@ -59036,7 +59056,7 @@ pvJ
 ath
 fFt
 fFt
-fFt
+sjK
 lOX
 pFn
 pFn
@@ -59191,7 +59211,7 @@ jBH
 oVj
 lVs
 syU
-gGb
+fPi
 hBT
 jnM
 bXQ
@@ -59256,7 +59276,7 @@ aYC
 aII
 aCd
 aCd
-ukG
+iKQ
 aOa
 aOA
 aXq
@@ -59482,7 +59502,7 @@ aVd
 aYX
 aKf
 axT
-dYp
+xlh
 ajM
 ahW
 ahZ
@@ -59528,13 +59548,13 @@ aqa
 aZu
 uby
 nve
-dqf
+ryT
 hYh
-ipT
+ycJ
 oGT
-ipT
+ycJ
 hYh
-dqf
+ryT
 ceP
 axO
 uby
@@ -59544,13 +59564,13 @@ djz
 djz
 djz
 dpy
-idR
+nQP
 djz
 djz
 djz
 djz
 djz
-idR
+nQP
 dpy
 jGp
 djz
@@ -59739,7 +59759,7 @@ aAg
 ale
 aqR
 axT
-dYp
+xlh
 ahQ
 ahW
 aia
@@ -59787,18 +59807,18 @@ ivk
 ceP
 kYg
 hYh
-jKy
+miC
 aqa
-msF
+kCb
 hYh
-iKF
+dqf
 ceP
 uby
 aZu
 aZu
 bSh
 djz
-aUo
+okT
 djz
 djz
 djz
@@ -59996,7 +60016,7 @@ aiV
 aiV
 aiV
 aiV
-anN
+rFg
 ahQ
 ahW
 aib
@@ -60042,13 +60062,13 @@ aqa
 aZu
 aZu
 tTX
-dqf
+ryT
 hYh
-ipT
+ycJ
 oGT
-ipT
+ycJ
 hYh
-dqf
+ryT
 ceP
 fEn
 aZu
@@ -60058,7 +60078,7 @@ djz
 djz
 djz
 djz
-blM
+roZ
 djz
 djz
 djz
@@ -60219,9 +60239,9 @@ bgY
 kME
 hSK
 gIE
-xWS
+plc
 tdW
-lma
+qxb
 bXQ
 oaW
 oaW
@@ -60322,9 +60342,9 @@ djz
 djz
 djz
 djz
-aUo
+okT
 djz
-xOV
+tnW
 cvJ
 bSh
 jJG
@@ -60558,9 +60578,9 @@ uby
 vDv
 aqa
 aqa
-iKF
-kYg
 dqf
+kYg
+ryT
 aqa
 aqa
 bhI
@@ -60568,14 +60588,14 @@ aZu
 uby
 uwf
 bSh
-pqK
+lPs
 djz
 djz
 djz
 djz
 djz
 djz
-pJy
+oXL
 djz
 djz
 djz
@@ -60768,7 +60788,7 @@ ajb
 ajf
 afV
 ajk
-rrr
+aYN
 ahW
 aie
 aim
@@ -61025,7 +61045,7 @@ ajc
 ajg
 afZ
 ajx
-rrr
+aYN
 ahW
 aif
 aim
@@ -61088,7 +61108,7 @@ djz
 djz
 djz
 djz
-aUo
+okT
 djz
 djz
 djz
@@ -61103,7 +61123,7 @@ jzQ
 uXm
 ath
 knz
-plb
+rBH
 aVi
 atm
 azg
@@ -61343,16 +61363,16 @@ djz
 djz
 djz
 djz
-kMg
+nwv
 djz
 djz
 djz
 djz
 djz
-oIc
+qqd
 djz
 djz
-blM
+roZ
 djz
 bSh
 fot
@@ -61360,7 +61380,7 @@ jzQ
 uXm
 pkb
 dTp
-uLa
+rHd
 aVi
 aVi
 aAM
@@ -61504,9 +61524,9 @@ aWd
 avj
 aNF
 bXQ
-xWS
+plc
 tdW
-lma
+qxb
 bXQ
 pyB
 oaW
@@ -61539,7 +61559,7 @@ ajd
 ajf
 afV
 ahO
-xrM
+pmw
 ahU
 aih
 ain
@@ -61604,7 +61624,7 @@ djz
 djz
 djz
 djz
-vEY
+rfr
 djz
 djz
 djz
@@ -61761,7 +61781,7 @@ aWd
 lVr
 aFA
 bXQ
-gGb
+fPi
 hBT
 jnM
 bXQ
@@ -61796,7 +61816,7 @@ ajd
 ajf
 afV
 aFf
-rrr
+aYN
 ahV
 aig
 aig
@@ -61855,10 +61875,10 @@ fEn
 bSh
 djz
 djz
-aUo
+okT
 djz
 djz
-blM
+roZ
 djz
 djz
 djz
@@ -62018,7 +62038,7 @@ aWd
 eNy
 aNF
 qOs
-gGb
+fPi
 hBT
 jnM
 qOs
@@ -62053,7 +62073,7 @@ aje
 ajL
 afV
 aFf
-rrr
+aYN
 ahW
 ajT
 aio
@@ -62110,21 +62130,21 @@ aUq
 aqa
 aqa
 bSh
-pqK
+lPs
 djz
 djz
 djz
 djz
 djz
 djz
-qsl
+hTm
 djz
 djz
 djz
 djz
 djz
 djz
-dyd
+uql
 bSh
 fot
 jzQ
@@ -62275,7 +62295,7 @@ aWd
 vQN
 aNF
 bXQ
-gGb
+fPi
 hBT
 jnM
 bXQ
@@ -62310,7 +62330,7 @@ aiV
 aiV
 afV
 aFf
-rrr
+aYN
 ahW
 aij
 aio
@@ -62370,8 +62390,8 @@ bSh
 xDs
 djz
 djz
-laI
-dvO
+mEA
+xLO
 djz
 djz
 djz
@@ -62388,7 +62408,7 @@ jzQ
 uXm
 ath
 rKr
-uLa
+rHd
 aVi
 atm
 aBZ
@@ -62532,7 +62552,7 @@ aWd
 avy
 aMe
 bXQ
-gGb
+fPi
 hBT
 gBl
 bXQ
@@ -62567,7 +62587,7 @@ hny
 ezH
 afV
 akf
-xWC
+qXF
 ahW
 ahX
 aip
@@ -62627,8 +62647,8 @@ bSh
 djz
 djz
 djz
-dhZ
-eQv
+fIt
+lXL
 djz
 djz
 djz
@@ -62636,7 +62656,7 @@ djz
 djz
 djz
 djz
-aUo
+okT
 djz
 djz
 bSh
@@ -62881,13 +62901,13 @@ uJb
 aZu
 axO
 bSh
-blM
+roZ
 djz
 djz
-eJw
-wJd
+hCz
+cAG
 djz
-aUo
+okT
 djz
 djz
 djz
@@ -63046,7 +63066,7 @@ aFI
 aNF
 avj
 bXQ
-gGb
+fPi
 hBT
 jnM
 bXQ
@@ -63081,7 +63101,7 @@ duE
 bDp
 afV
 aFf
-rrr
+aYN
 jQv
 uby
 fEn
@@ -63140,7 +63160,7 @@ aqa
 bSh
 djz
 djz
-xPF
+sXy
 wcN
 djz
 jDu
@@ -63148,7 +63168,7 @@ ldD
 hwU
 bcc
 mHB
-xPF
+sXy
 wcN
 djz
 djz
@@ -63303,9 +63323,9 @@ aYl
 aYl
 aYl
 bXQ
-pMX
-hnN
 aLG
+hnN
+uhE
 bXQ
 aYl
 aYl
@@ -63339,7 +63359,7 @@ aYl
 afV
 ajn
 ajD
-iFC
+sXf
 ajF
 ajF
 ajF
@@ -63393,7 +63413,7 @@ aqa
 aqa
 aqa
 wpm
-hEp
+pEz
 bSh
 bSh
 bSh
@@ -63416,7 +63436,7 @@ jzQ
 uXm
 pkb
 plb
-uLa
+rHd
 aVi
 asG
 aCA
@@ -63521,81 +63541,81 @@ ata
 aWd
 aWJ
 aYl
-pGX
+qhT
 kHW
-poS
+gGb
 aow
-poS
-poS
-poS
+gGb
+gGb
+gGb
 aqJ
 ayM
 aEc
 aYV
-poS
-poS
-poS
-poS
-poS
-poS
-poS
+gGb
+gGb
+gGb
+gGb
+gGb
+gGb
+gGb
 aJA
 aow
-poS
+gGb
 hUc
 ajW
-poS
-poS
-poS
-poS
+gGb
+gGb
+gGb
+gGb
 aJA
-poS
+gGb
 aqJ
 ayM
 aqJ
-poS
-poS
-poS
-poS
+gGb
+gGb
+gGb
+gGb
 aJA
 aow
-poS
-dNb
+gGb
+fsb
 mJT
-mTE
-poS
-poS
-poS
+xgv
+gGb
+gGb
+gGb
 aJA
-poS
-poS
-poS
-poS
+gGb
+gGb
+gGb
+gGb
 aYV
 aqJ
 ayM
 aEc
-poS
-poS
-poS
-poS
+gGb
+gGb
+gGb
+gGb
 eWg
-poS
+gGb
 aJA
-poS
+gGb
 aow
-poS
+gGb
 bOs
-poS
-poS
-poS
+gGb
+gGb
+gGb
 aJA
-poS
+gGb
 aqJ
-avJ
-mYR
-hpH
-vnM
+gyO
+rGA
+miF
+wlz
 oJO
 aIj
 apw
@@ -63641,16 +63661,16 @@ apC
 aZb
 apC
 apC
-kpu
+uPZ
 mRx
 ppc
 gfR
 gfR
 gfR
 gfR
-cLv
-lNg
-udb
+eVI
+bbd
+cEV
 meR
 rzy
 fbG
@@ -63672,7 +63692,7 @@ gTR
 jzQ
 iQh
 ath
-cbP
+plb
 doV
 aVi
 asG
@@ -63909,13 +63929,13 @@ aKB
 aKB
 aKB
 aTQ
-lch
+fML
 lOs
-lch
-lch
-lch
-lch
-lch
+fML
+fML
+fML
+fML
+fML
 vXl
 aBx
 aBH
@@ -64035,81 +64055,81 @@ avD
 avD
 aKX
 aYl
+iAN
+aBi
+anN
 aSL
-aBi
-vyc
-eFT
-vyc
-vyc
-vyc
-cOT
-fLC
+anN
+anN
+anN
+eJi
+yfo
 aHU
-vyc
-vyc
-vyc
-vyc
-vyc
-vyc
-vyc
-vyc
-vyc
+anN
+anN
+anN
+anN
+anN
+anN
+anN
+anN
+anN
 aBi
-vyc
-vyc
-vyc
+anN
+anN
+anN
 aEi
-vyc
-vyc
-vyc
-vyc
-vyc
+anN
+anN
+anN
+anN
+anN
 aHU
-fLC
+yfo
 aTb
 cmR
-vno
-vyc
-vyc
-vyc
-vyc
-vyc
-vyc
+ekI
+anN
+anN
+anN
+anN
+anN
+anN
 aBi
-vyc
-vyc
+anN
+anN
 ajZ
-vyc
-vyc
-vyc
-iOC
+anN
+anN
+anN
+guB
 aUk
-vno
-vyc
-cOT
-fLC
-cOT
-vyc
-vyc
+ekI
+anN
+eJi
+yfo
+eJi
+anN
+anN
 ajZ
-vyc
-vyc
-vyc
-vyc
-vyc
+anN
+anN
+anN
+anN
+anN
 aBi
-vyc
-vyc
-vyc
-vyc
-vyc
-vyc
+anN
+anN
+anN
+anN
+anN
+anN
 aIF
 aHU
-cJe
-boH
-feE
-doZ
+avJ
+vyc
+urL
+rhB
 eAM
 uuA
 aYz
@@ -64323,9 +64343,9 @@ aYl
 aYl
 aYl
 jDb
-eSR
+phi
 mIh
-crC
+eSR
 jDb
 aYl
 aYl
@@ -64340,7 +64360,7 @@ aYl
 aYl
 aYl
 pff
-jtf
+lmP
 ibI
 aYl
 aYl
@@ -64366,8 +64386,8 @@ aYl
 aYl
 afV
 aCl
-rrr
-elD
+aYN
+dAn
 ajF
 ajF
 ajF
@@ -64580,9 +64600,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -64596,9 +64616,9 @@ aoo
 aoo
 aoo
 aYl
-kzK
+vTK
 aUk
-mTE
+xgv
 jwM
 sgl
 sgl
@@ -64622,8 +64642,8 @@ aoo
 aoo
 aoo
 afV
+spW
 aYN
-rrr
 afV
 aoo
 aoo
@@ -64681,24 +64701,24 @@ oHr
 rlg
 dBB
 aRs
-eQK
-rNP
-eJV
-oOY
+blM
+dTL
+rtN
+aUo
 aRs
-rVh
-buO
+rwQ
+dkx
 aIm
 aIm
-ous
+ftm
 aIm
-eJV
+rtN
 aIm
-buO
-rNP
-eJV
+dkx
+dTL
+rtN
 aIm
-qIK
+nQF
 aFv
 aGj
 unD
@@ -64837,9 +64857,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 jLU
-phi
+rNP
 wUI
 aoo
 aoo
@@ -64938,13 +64958,13 @@ aRs
 aRs
 aRs
 aRs
-xRo
+jmT
 aIm
-eJV
-buO
-neC
+rtN
+dkx
+ilZ
 aIm
-eJV
+rtN
 aIm
 aRs
 aRs
@@ -64954,8 +64974,8 @@ aRs
 aIm
 aIm
 aIm
-rNP
-bsn
+dTL
+pEl
 aFv
 aGj
 unD
@@ -65110,9 +65130,9 @@ aoo
 aoo
 aoo
 aYl
-pCY
-vyc
-vyc
+vpA
+anN
+anN
 sgl
 sgl
 sgl
@@ -65192,27 +65212,27 @@ awK
 aJb
 asX
 aIm
-eJV
-ous
+rtN
+ftm
 aIm
-buO
+dkx
 aIm
-jjp
+uUH
 aIm
 aRs
-eJV
-buO
-bsn
+rtN
+dkx
+pEl
 aRs
-kCy
-oIZ
-aXv
+hDL
+iMf
+saB
 aRs
-rVh
-vhm
-gcY
+rwQ
+amT
+rvM
 aIm
-eJV
+rtN
 aFv
 aGj
 aSw
@@ -65351,9 +65371,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 roj
-phi
+rNP
 wUI
 aoo
 aoo
@@ -65608,9 +65628,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -65865,7 +65885,7 @@ aoo
 aoo
 aoo
 jDb
-qin
+eJV
 tUT
 pCT
 jDb
@@ -66122,9 +66142,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -66379,9 +66399,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -66638,7 +66658,7 @@ aoo
 wUI
 rgd
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -67150,9 +67170,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -67407,9 +67427,9 @@ aoo
 aoo
 aoo
 jDb
-qin
+eJV
 tUT
-phi
+rNP
 jDb
 aoo
 aoo
@@ -67664,9 +67684,9 @@ aoo
 aoo
 aoo
 jDb
-eSR
+phi
 mIh
-crC
+eSR
 jDb
 aoo
 aoo
@@ -67921,9 +67941,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -68178,9 +68198,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -68692,9 +68712,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 roj
-phi
+rNP
 wUI
 aoo
 aoo
@@ -68949,9 +68969,9 @@ aGr
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -69206,7 +69226,7 @@ aGr
 aoo
 aoo
 jDb
-qin
+eJV
 tUT
 pCT
 jDb
@@ -69463,9 +69483,9 @@ aGr
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -69720,9 +69740,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -69979,7 +69999,7 @@ aoo
 wUI
 rgd
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -70311,22 +70331,22 @@ aRC
 aQj
 aPP
 aWn
-fmT
+yaF
 aWn
 aWn
 aWn
 aWn
-amT
+qBJ
 aWn
 aWn
-rnz
+etF
 aWn
 aWn
 aWn
 aWn
 aWn
-amT
-rnz
+qBJ
+etF
 axR
 feL
 aXJ
@@ -70491,9 +70511,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 afu
@@ -70568,12 +70588,12 @@ acJ
 aHr
 aHc
 aGJ
-jZP
+cbP
 aGJ
 aGJ
 aGJ
 aGJ
-jZP
+cbP
 aGJ
 aGJ
 aGJ
@@ -70582,7 +70602,7 @@ aNR
 aGJ
 aGJ
 aGJ
-jZP
+cbP
 aGJ
 all
 axd
@@ -70748,9 +70768,9 @@ aoo
 aoo
 aoo
 jDb
-qin
+eJV
 tUT
-phi
+rNP
 jDb
 aoo
 afu
@@ -70825,12 +70845,12 @@ aRC
 aRC
 aPP
 aMl
-ooX
+giK
 anm
 aOy
 anm
 anm
-fqu
+siL
 anm
 aMl
 aOy
@@ -70839,8 +70859,8 @@ aRB
 aWE
 aOy
 anm
-fqu
-vYc
+siL
+mqP
 bcx
 mER
 aXJ
@@ -71005,9 +71025,9 @@ aoo
 aoo
 aoo
 jDb
-eSR
+phi
 mIh
-crC
+eSR
 jDb
 aoo
 afu
@@ -71262,9 +71282,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 afu
@@ -71346,11 +71366,11 @@ aoo
 aMG
 aFo
 aIM
-xHi
+bGW
 aIM
 aIM
 ajr
-kZT
+fFi
 aDa
 aMG
 aoo
@@ -71519,9 +71539,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 afu
@@ -71862,7 +71882,7 @@ aXR
 ask
 ask
 ask
-oYz
+iVf
 awp
 aSh
 aZB
@@ -72033,9 +72053,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 roj
-phi
+rNP
 wUI
 aoo
 aoo
@@ -72290,9 +72310,9 @@ aoo
 aoo
 aoo
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aoo
 aoo
@@ -72547,7 +72567,7 @@ aoo
 aoo
 aoo
 jDb
-qin
+eJV
 tUT
 pCT
 jDb
@@ -72804,9 +72824,9 @@ aoo
 aoo
 aaa
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -73061,9 +73081,9 @@ aoo
 aoo
 aaa
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -73318,9 +73338,9 @@ aaa
 aaa
 aaa
 jDb
-eSR
+phi
 mIh
-crC
+eSR
 jDb
 aaa
 aaa
@@ -73575,9 +73595,9 @@ aaa
 aaa
 aaa
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -73832,9 +73852,9 @@ aaa
 aaa
 aaa
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -74346,9 +74366,9 @@ aaa
 aaa
 aaa
 wUI
-qin
+eJV
 roj
-phi
+rNP
 wUI
 aaa
 aaa
@@ -74603,9 +74623,9 @@ aaa
 aaa
 aaa
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -74860,7 +74880,7 @@ aaa
 aaa
 aaa
 jDb
-qin
+eJV
 tUT
 pCT
 jDb
@@ -75117,9 +75137,9 @@ aaa
 aaa
 aaa
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -75374,9 +75394,9 @@ aaa
 aaa
 aaa
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -75631,7 +75651,7 @@ jDb
 jDb
 jDb
 jDb
-iNC
+qrQ
 fGb
 eNF
 jDb
@@ -75887,11 +75907,11 @@ aaa
 elk
 fcK
 kIT
-dtn
-lId
+iFy
+dhb
 tUT
-loQ
-hGc
+kpO
+ygn
 kIT
 bYH
 elk
@@ -76144,11 +76164,11 @@ aaa
 elk
 eiU
 ney
-qin
+eJV
 eoz
 ivM
 vfP
-phi
+rNP
 ney
 wXo
 elk
@@ -76401,11 +76421,11 @@ aaa
 elk
 fiQ
 ney
-qin
+eJV
 fiI
 vtU
 evk
-phi
+rNP
 ney
 kOJ
 elk
@@ -76658,11 +76678,11 @@ aaa
 elk
 ooq
 ney
-qin
+eJV
 hph
 tnb
 rUg
-phi
+rNP
 ney
 unR
 elk
@@ -76915,11 +76935,11 @@ aaa
 elk
 ney
 ney
-qin
+eJV
 lkc
 qoK
 qLp
-phi
+rNP
 ney
 ney
 elk
@@ -77172,11 +77192,11 @@ aaa
 elk
 xDy
 ney
-qin
+eJV
 sSd
 cCL
 eoA
-phi
+rNP
 ney
 pbr
 elk
@@ -77429,11 +77449,11 @@ aaa
 elk
 fiQ
 ney
-qin
+eJV
 tOa
 vtU
 tOa
-phi
+rNP
 ney
 hKe
 elk
@@ -77686,11 +77706,11 @@ aaa
 elk
 eiU
 ney
-qin
+eJV
 eoz
 wOd
 vfP
-phi
+rNP
 ney
 wXo
 elk
@@ -77944,10 +77964,10 @@ elk
 bsG
 ney
 nLU
-sXA
+eJw
 fAD
-vBA
-yht
+mtn
+iwi
 ney
 xPf
 elk
@@ -78201,9 +78221,9 @@ cFi
 dbS
 dbS
 cFi
-qQF
+mjK
 fGb
-ouw
+qQF
 elk
 elk
 elk
@@ -78458,9 +78478,9 @@ hIV
 uBe
 kdo
 dbS
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -78715,9 +78735,9 @@ qhe
 hCk
 wNJ
 dbS
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -78972,7 +78992,7 @@ xHV
 eGa
 oqc
 dbS
-qin
+eJV
 tUT
 eRl
 jDb
@@ -79229,7 +79249,7 @@ hqF
 iwY
 bDz
 tAN
-qEh
+fpx
 ivM
 tHY
 wUI
@@ -79486,9 +79506,9 @@ iig
 iwY
 qhe
 cFi
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -80000,9 +80020,9 @@ cFi
 cFi
 cFi
 cFi
-eSR
+phi
 mIh
-crC
+eSR
 jDb
 aaa
 aaa
@@ -80257,9 +80277,9 @@ aaa
 aaa
 aaa
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -80516,7 +80536,7 @@ aaa
 wUI
 rgd
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -81030,7 +81050,7 @@ aaa
 wUI
 gDn
 tUT
-phi
+rNP
 wUI
 aaa
 aaa
@@ -81285,9 +81305,9 @@ aaa
 wUI
 wUI
 wUI
-qin
+eJV
 tUT
-phi
+rNP
 wUI
 wUI
 wUI
@@ -81542,9 +81562,9 @@ pjZ
 pjZ
 qGA
 oAu
-eQs
+cCT
 ovw
-woR
+bgz
 oAu
 wFO
 tZp
@@ -82312,11 +82332,11 @@ xPn
 fUi
 xPn
 gpP
-ucK
-sKe
+dIS
+cRI
 kof
-vBA
-ucK
+mtn
+dIS
 aHC
 ndN
 mUq
@@ -82570,7 +82590,7 @@ aaa
 wUI
 wUI
 wUI
-qin
+eJV
 kof
 pAv
 wUI
@@ -82829,7 +82849,7 @@ aaa
 wUI
 rgd
 kof
-phi
+rNP
 wUI
 aaa
 aaa
@@ -83084,7 +83104,7 @@ aaa
 aaa
 aaa
 wUI
-qEh
+fpx
 kyE
 tHY
 wUI
@@ -83343,7 +83363,7 @@ aaa
 wUI
 gDn
 mdY
-phi
+rNP
 wUI
 aaa
 aaa

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -3892,10 +3892,16 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ahJ" = (
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3983,6 +3989,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ahP" = (
@@ -4016,6 +4025,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ahR" = (
@@ -4034,6 +4044,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ahS" = (
@@ -4044,6 +4055,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ahT" = (
@@ -4053,6 +4065,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
@@ -4610,6 +4625,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ajl" = (
@@ -4626,6 +4644,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
@@ -4647,6 +4668,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ajo" = (
@@ -4659,6 +4683,7 @@
 /area/library)
 "ajq" = (
 /obj/machinery/light,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ajr" = (
@@ -4726,6 +4751,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ajy" = (
@@ -4767,6 +4795,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ajE" = (
@@ -4845,6 +4874,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ajN" = (
@@ -4933,6 +4963,9 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "ajX" = (
@@ -4950,6 +4983,9 @@
 "ajZ" = (
 /obj/machinery/camera/autoname{
 	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -5006,6 +5042,9 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "akg" = (
@@ -5157,12 +5196,11 @@
 /turf/simulated/floor/bmarble,
 /area/crew_quarters/wedding_chapel)
 "akA" = (
-/obj/machinery/computer/mecha{
-	dir = 4;
-	tag = "icon-computer (EAST)"
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
+	},
+/obj/machinery/computer/mecha{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/rnd/rdoffice)
@@ -5321,6 +5359,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "akP" = (
@@ -5612,6 +5651,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aln" = (
@@ -5690,6 +5730,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "alu" = (
@@ -5715,6 +5756,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/yjunction,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "alw" = (
@@ -6361,6 +6403,9 @@
 /area/exploration/hanger)
 "amP" = (
 /obj/structure/flora/pottedplant/flower,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "amQ" = (
@@ -6379,15 +6424,27 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "amS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "amT" = (
-/turf/simulated/wall/r_wall,
-/area/medical/medbay)
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "amU" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -6503,6 +6560,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "anj" = (
@@ -6530,6 +6588,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "anm" = (
@@ -6540,6 +6599,9 @@
 /area/exploration/hallway)
 "ann" = (
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6787,13 +6849,12 @@
 	name = "\improper Research Breakroom"
 	})
 "anN" = (
-/obj/structure/railing,
-/obj/effect/floor_decal/corner_kafel/blue{
-	dir = 6;
-	tag = "icon-corner_kafel (SOUTHEAST)"
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "anO" = (
 /obj/structure/railing{
 	dir = 4
@@ -7094,6 +7155,9 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "aox" = (
@@ -7281,6 +7345,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aoQ" = (
@@ -8322,6 +8387,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "aqK" = (
@@ -8369,6 +8437,9 @@
 /area/hallway/primary/deckthree/aft)
 "aqQ" = (
 /obj/structure/flora/pottedplant/decorative,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aqR" = (
@@ -9323,6 +9394,9 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "asA" = (
@@ -10191,6 +10265,9 @@
 	pixel_y = -22
 	},
 /obj/structure/flora/pottedplant/drooping,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aui" = (
@@ -10357,6 +10434,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
@@ -10959,6 +11039,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "avB" = (
@@ -11061,6 +11144,9 @@
 /obj/machinery/door/airlock/glass{
 	name = "Fore Hallway - Deck 2"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "avK" = (
@@ -11147,6 +11233,10 @@
 	faction = "neutral";
 	movement_sound = null;
 	name = "Skitters"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/pathfinder_office)
@@ -11376,16 +11466,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/security_port)
 "awp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
@@ -12012,6 +12100,10 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 6;
+	tag = "icon-corner_kafel (SOUTHEAST)"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "axv" = (
@@ -12741,6 +12833,9 @@
 	})
 "ayM" = (
 /obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "ayN" = (
@@ -13424,7 +13519,7 @@
 /area/security/detectives_office)
 "aAb" = (
 /turf/simulated/wall,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "aAc" = (
 /obj/machinery/atmospherics/unary/engine/bigger{
 	dir = 1
@@ -14047,6 +14142,9 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -14689,6 +14787,9 @@
 /obj/structure/sign/deck/third{
 	pixel_y = 32
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aCm" = (
@@ -14911,6 +15012,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aCE" = (
@@ -14971,6 +15073,9 @@
 /area/chapel/office)
 "aCK" = (
 /obj/machinery/camera/autoname,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aCL" = (
@@ -15633,6 +15738,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "aEd" = (
@@ -15689,6 +15797,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -16036,6 +16147,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
@@ -16736,7 +16850,7 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/medical/medbay)
+/area/medical/medbay2)
 "aGN" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -17117,6 +17231,9 @@
 	dir = 1;
 	pixel_y = -30
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard_airlock_s)
 "aHD" = (
@@ -17155,6 +17272,9 @@
 "aHH" = (
 /obj/structure/sign/deck/third{
 	pixel_y = 32
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
@@ -17234,6 +17354,9 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "aHV" = (
@@ -17277,6 +17400,10 @@
 /area/crew_quarters/locker/upper/room2)
 "aIc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/carpet/tealcarpet,
 /area/crew_quarters/heads/cmo)
 "aId" = (
@@ -17506,6 +17633,9 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -17890,6 +18020,9 @@
 /area/medical/chemistry)
 "aJA" = (
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -18354,7 +18487,6 @@
 	layer = 3.3;
 	pixel_y = 26
 	},
-/obj/machinery/computer/mecha,
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
@@ -18442,6 +18574,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -18952,6 +19087,7 @@
 	})
 "aLG" = (
 /obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "aLH" = (
@@ -20191,6 +20327,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aON" = (
@@ -20905,6 +21042,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aQw" = (
@@ -21426,6 +21564,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "aRJ" = (
@@ -21850,6 +21991,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "aSM" = (
@@ -21960,6 +22104,9 @@
 "aTb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -22490,12 +22637,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
 "aUo" = (
-/obj/effect/floor_decal/corner_kafel/blue{
-	dir = 5;
-	tag = "icon-corner_kafel (NORTHEAST)"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/construction)
 "aUq" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance,
@@ -23827,6 +23971,11 @@
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/pathfinder_office)
+"aXv" = (
+/obj/effect/floor_decal/rust,
+/obj/item/clothing/under/suit_jacket/gambler,
+/turf/simulated/floor/plating,
+/area/space)
 "aXw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -23855,6 +24004,9 @@
 "aXx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
@@ -24050,6 +24202,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 6;
+	tag = "icon-corner_kafel (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -24352,16 +24508,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aYN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
+/area/hallway/primary/deckthree/central)
 "aYO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -24416,6 +24578,9 @@
 "aYV" = (
 /obj/structure/sign/deck/third{
 	pixel_x = -29
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -25156,6 +25321,9 @@
 	layer = 3.3;
 	pixel_y = 26
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "bkl" = (
@@ -25175,9 +25343,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
 "blM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/construction)
 "bmh" = (
@@ -25186,6 +25352,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/exploration/hanger)
+"boH" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "boS" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
@@ -25209,6 +25381,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"bsn" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/space)
 "bsG" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/carpet,
@@ -25217,6 +25396,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"buO" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/space)
 "bxM" = (
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
@@ -25230,6 +25413,9 @@
 /area/hallway/station/docking_hall_airlock_s)
 "bCn" = (
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -25267,6 +25453,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"bGS" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "bJT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -25282,10 +25474,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
-"bMk" = (
-/obj/structure/barricade/planks,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay_aft)
 "bOm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -25299,6 +25487,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -25316,11 +25507,15 @@
 /area/security/checkpoint)
 "bTJ" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "bVJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_w)
@@ -25328,6 +25523,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass{
 	name = "Fore Hallway - Deck 2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
@@ -25439,6 +25637,11 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"crC" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "cvJ" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -25470,6 +25673,9 @@
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_n)
 "cBR" = (
@@ -25522,6 +25728,32 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"cJe" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Fore Hallway - Deck 2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"cKb" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
+"cLv" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "cMy" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -25555,12 +25787,22 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_w)
+"cOT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "cPi" = (
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
 	pixel_y = -30
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_s)
 "cRo" = (
@@ -25574,6 +25816,9 @@
 "cTt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -25599,14 +25844,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"cWd" = (
-/obj/item/frame,
-/turf/simulated/floor/plating,
-/area/construction)
 "cXq" = (
 /obj/effect/shuttle_landmark/arfs/deck3/dockarm/south/starboard,
 /turf/space,
 /area/space)
+"cYt" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "dax" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25637,6 +25884,10 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"deI" = (
+/obj/structure/barricade/planks,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "dfo" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -25655,7 +25906,15 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
+"dhZ" = (
+/obj/fiftyspawner/plastic,
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/fiftyspawner/plastic,
+/turf/simulated/floor/plating,
+/area/construction)
 "djz" = (
 /turf/simulated/floor/plating,
 /area/construction)
@@ -25667,6 +25926,10 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engineering)
+"doZ" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "dpy" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -25676,9 +25939,14 @@
 "dqf" = (
 /obj/structure/table/reinforced,
 /obj/random/maintenance/foodstuff,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"dtn" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "dtu" = (
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
@@ -25686,6 +25954,22 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"dvO" = (
+/obj/item/weapon/rcd,
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/construction)
+"dyd" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/construction)
 "dBB" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -25715,6 +25999,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"dNb" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "dNc" = (
 /obj/structure/bed/chair/bay,
 /turf/simulated/floor/carpet,
@@ -25771,6 +26061,12 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"dYp" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "dZs" = (
 /obj/structure/bed/chair/bay/comfy,
 /turf/simulated/floor/plating,
@@ -25787,8 +26083,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "ebl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25871,6 +26172,16 @@
 "elk" = (
 /turf/simulated/wall,
 /area/hallway/station/docking_hall_starboard)
+"elD" = (
+/obj/structure/sign/directions/science{
+	pixel_y = -5
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = -12
+	},
+/turf/simulated/wall,
+/area/hallway/primary/deckthree/central)
 "emY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -25987,6 +26298,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"eFT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "eGa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -25996,14 +26327,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
-"eJV" = (
-/obj/fiftyspawner/plastic,
+"eJw" = (
+/obj/fiftyspawner/glass,
 /obj/structure/closet/crate{
-	dir = 2
+	dir = 1
 	},
-/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/glass,
 /turf/simulated/floor/plating,
 /area/construction)
+"eJV" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/space)
 "eKj" = (
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/dark,
@@ -26021,8 +26356,17 @@
 /obj/machinery/door/airlock/glass{
 	name = "Fore Hallway - Deck 2"
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"eNG" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_external/public{
+	name = "Docking Arm"
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "ePN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -26049,15 +26393,38 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"eQs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
+"eQv" = (
+/obj/fiftyspawner/rods,
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/fiftyspawner/rods,
+/turf/simulated/floor/plating,
+/area/construction)
+"eQK" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/space)
 "eRl" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "eSR" = (
 /obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "eUF" = (
@@ -26090,6 +26457,9 @@
 	dir = 4;
 	pixel_x = -27;
 	tag = "icon-extinguisher_closed (EAST)"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -26143,15 +26513,23 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
-"fef" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 10
+"feE" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
+/area/hallway/primary/deckthree/central)
 "feL" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 9
@@ -26216,6 +26594,19 @@
 /obj/structure/bed/chair/bay,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
+"fmT" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "fot" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -26225,6 +26616,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"fqu" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "frr" = (
 /obj/structure/railing{
 	dir = 4
@@ -26336,6 +26736,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall_starboard)
+"fLC" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "fQO" = (
 /obj/effect/floor_decal/corner_kafel/blue{
 	dir = 5;
@@ -26343,7 +26750,7 @@
 	},
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay2)
 "fQP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26380,8 +26787,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"gcY" = (
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/space)
 "gfR" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -26411,6 +26825,9 @@
 "gpP" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard_airlock_n)
@@ -26451,10 +26868,14 @@
 /area/maintenance/medbay_aft)
 "gBl" = (
 /obj/machinery/light,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "gBt" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "gCi" = (
@@ -26466,6 +26887,9 @@
 	layer = 3.3;
 	pixel_y = 26
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "gEp" = (
@@ -26475,12 +26899,11 @@
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
 "gGb" = (
-/obj/effect/floor_decal/corner_kafel/blue{
-	dir = 10;
-	tag = "icon-corner_kafel (SOUTHWEST)"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "gHu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26512,6 +26935,9 @@
 "gIu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera/autoname,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "gIE" = (
@@ -26543,6 +26969,12 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"gTC" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "gTR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -26571,15 +27003,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
-"hbC" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay_aft)
 "hbP" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -26617,7 +27040,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "hny" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -26667,6 +27090,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall_starboard)
+"hpH" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "hqF" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -26742,6 +27185,15 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_s)
+"hEp" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "hFL" = (
 /obj/random/pottedplant,
 /obj/machinery/firealarm{
@@ -26762,6 +27214,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "hFW" = (
@@ -26772,6 +27227,12 @@
 /obj/random/pottedplant,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"hGc" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "hGQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -26783,7 +27244,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/hallway/primary/deckthree/aft)
 "hHb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26863,6 +27324,9 @@
 	pixel_x = -28;
 	tag = "icon-extinguisher_closed (EAST)"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "hWP" = (
@@ -26871,7 +27335,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "hXb" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/sec,
@@ -26898,6 +27362,10 @@
 /obj/structure/sign/directions/stairs_down{
 	pixel_y = -25
 	},
+/obj/machinery/door/airlock/glass{
+	name = "Fore Stairway"
+	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "ici" = (
@@ -26905,6 +27373,12 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"idR" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "ihu" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -26935,12 +27409,12 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"ioJ" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
+"ipT" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/contraband,
+/obj/random/contraband,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "iuR" = (
 /obj/machinery/light,
 /turf/simulated/open,
@@ -27008,6 +27482,9 @@
 /area/security/checkpoint)
 "iwD" = (
 /obj/machinery/camera/autoname,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "iwQ" = (
@@ -27022,6 +27499,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -27062,6 +27544,13 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"iFC" = (
+/obj/structure/sign/directions/medical{
+	pixel_y = 6
+	},
+/obj/structure/sign/directions/engineering,
+/turf/simulated/wall,
+/area/hallway/primary/deckthree/central)
 "iGa" = (
 /obj/machinery/door/airlock/angled_tgmc{
 	dir = 4;
@@ -27076,10 +27565,21 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"iKF" = (
+/obj/structure/table/reinforced,
+/obj/random/contraband,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "iLs" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/engineering)
+"iMk" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "iNh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -27092,6 +27592,22 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"iNC" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Fore Hallway - Deck 2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
+"iOC" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
@@ -27158,12 +27674,20 @@
 /obj/effect/floor_decal/corner/purple/bordercorner,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"jjp" = (
+/obj/random/maintenance/clean,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "jmh" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "jnM" = (
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "joA" = (
@@ -27179,8 +27703,22 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/hallway/primary/deckthree/aft)
+"jpF" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "jpN" = (
 /obj/machinery/light,
 /obj/effect/map_helper/airlock/sensor/int_sensor,
@@ -27189,6 +27727,7 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_s)
 "jqY" = (
@@ -27196,6 +27735,13 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"jtf" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Fore Stairway"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "jud" = (
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
@@ -27237,6 +27783,9 @@
 /area/hallway/primary/deckthree/fore)
 "jwP" = (
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -27318,6 +27867,15 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"jKy" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "jLU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -27343,6 +27901,9 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_w)
 "jWE" = (
@@ -27367,6 +27928,20 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"jZP" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "kaU" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
@@ -27425,6 +28000,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"kpu" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "kql" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27487,6 +28068,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"kzK" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"kCy" = (
+/obj/effect/floor_decal/rust,
+/obj/item/clothing/head/collectable/petehat,
+/turf/simulated/floor/plating,
+/area/space)
 "kDP" = (
 /obj/structure/closet/crate{
 	dir = 2
@@ -27518,6 +28110,9 @@
 	pixel_x = -28;
 	tag = "icon-extinguisher_closed (EAST)"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "kIT" = (
@@ -27526,6 +28121,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
+"kMg" = (
+/obj/machinery/light/floortube{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "kME" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27556,14 +28157,46 @@
 /area/hallway/primary/deckthree/aft)
 "kYg" = (
 /obj/structure/table/reinforced,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"kZT" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/gateway)
+"laI" = (
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/item/weapon/pipe_dispenser,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/construction)
+"lch" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "lcT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/firealarm{
 	layer = 3.3;
 	pixel_y = 26
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
@@ -27596,6 +28229,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall_starboard)
+"lma" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "lnC" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -27612,6 +28252,12 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"loQ" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "ltj" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -27665,6 +28311,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "lBb" = (
@@ -27703,12 +28352,18 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"lId" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "lJu" = (
 /obj/effect/floor_decal/corner_kafel/blue/full{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay2)
 "lMN" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -27717,7 +28372,17 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
+"lNg" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 1;
+	tag = "icon-bordercolorcorner (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "lOs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27739,21 +28404,12 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
-"lQw" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
 "lSR" = (
 /obj/effect/floor_decal/corner_kafel/blue/full{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay2)
 "lVr" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -27847,6 +28503,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "mpd" = (
@@ -27865,7 +28522,7 @@
 "mpv" = (
 /obj/effect/floor_decal/corner_kafel/blue,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay2)
 "mpM" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -27881,15 +28538,11 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/hallway/primary/deckthree/aft)
 "mqc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/engineering)
-"msf" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/construction)
 "msj" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -27899,6 +28552,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"msF" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "mvu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -27981,6 +28645,7 @@
 /area/construction)
 "mId" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_s)
 "mIh" = (
@@ -28017,17 +28682,6 @@
 /area/crew_quarters/sleep{
 	name = "\improper Ball Room"
 	})
-"mKr" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/random/maintenance/foodstuff,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay_aft)
 "mMq" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -28066,10 +28720,22 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_airlock_w)
+"mTE" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "mUq" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall_starboard_airlock_s)
+"mYR" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "nao" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark,
@@ -28081,14 +28747,24 @@
 	pixel_y = -5
 	},
 /obj/structure/catwalk,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -28;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "ndN" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard_airlock_s)
 "ney" = (
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
+"neC" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/space)
 "ngC" = (
 /obj/random/trash,
 /obj/machinery/floodlight{
@@ -28131,13 +28807,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/medbay_aft)
-"nwg" = (
-/obj/item/weapon/rcd,
-/obj/structure/closet/crate{
-	dir = 2
-	},
-/turf/simulated/floor/plating,
-/area/construction)
 "nwy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -28146,6 +28815,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_w)
@@ -28165,13 +28837,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall)
-"nzN" = (
-/obj/structure/closet/crate{
-	dir = 2
-	},
-/obj/item/weapon/pipe_dispenser,
-/turf/simulated/floor/plating,
-/area/construction)
 "nDX" = (
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
@@ -28208,6 +28873,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_n)
 "nHu" = (
@@ -28220,6 +28888,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Docking Arm"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
@@ -28247,6 +28918,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
@@ -28306,7 +28980,9 @@
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engineering)
 "odu" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/reinforced{
+	name = "table of shame"
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -28320,8 +28996,12 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "odW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -28351,22 +29031,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
-"olx" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 1;
-	tag = "icon-bordercolorcorner (EAST)"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
 "olY" = (
 /obj/effect/floor_decal/corner_kafel/blue/full{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay2)
 "omH" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorblack{
@@ -28400,6 +29070,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"ooX" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "oqc" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -28425,12 +29108,28 @@
 "otx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera/autoname,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "oua" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"ous" = (
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/space)
+"ouw" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_external/public{
+	name = "Docking Arm"
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "ouH" = (
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/tiled/techfloor,
@@ -28456,14 +29155,18 @@
 /area/maintenance/station/deck_three/port_docking_arm)
 "oAu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "oCh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "oGT" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/maintenance/foodstuff,
@@ -28476,12 +29179,15 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood,
 /area/space)
-"oIx" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+"oIc" = (
+/obj/machinery/light/floortube,
 /turf/simulated/floor/plating,
 /area/construction)
+"oIZ" = (
+/obj/effect/floor_decal/rust,
+/obj/item/clothing/mask/mouthwheat,
+/turf/simulated/floor/plating,
+/area/space)
 "oJO" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -28515,6 +29221,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"oOY" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/space)
 "oVj" = (
 /obj/structure/filingcabinet/security,
 /turf/simulated/floor/tiled/dark,
@@ -28525,6 +29235,15 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"oYz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/gateway)
 "paK" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -28565,14 +29284,36 @@
 /obj/structure/sign/deck/third{
 	pixel_y = 32
 	},
+/obj/machinery/door/airlock/glass{
+	name = "Fore Stairway"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
 "phi" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
+"pjU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/construction)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "pjZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
@@ -28594,6 +29335,12 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"poS" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "ppc" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -28607,6 +29354,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"pqK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "prE" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/deckthree/central)
@@ -28637,6 +29390,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "pBy" = (
@@ -28673,8 +29427,15 @@
 	dir = 1;
 	pixel_y = -30
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"pCY" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "pFn" = (
 /obj/structure/table/rack/steel,
 /obj/structure/catwalk,
@@ -28692,6 +29453,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
+"pGX" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"pIU" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"pJy" = (
+/obj/machinery/light/floortube{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "pKZ" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
@@ -28702,6 +29482,13 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"pMX" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "pND" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -28779,15 +29566,25 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "qgJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_n)
 "qhe" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"qin" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "qiG" = (
 /obj/effect/shuttle_landmark/arfs/deck3/space/ne,
 /turf/space,
@@ -28824,6 +29621,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "qoK" = (
@@ -28857,6 +29655,12 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"qsl" = (
+/obj/machinery/light/floortube{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "qsL" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/engineering)
@@ -28893,14 +29697,20 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 5
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "qzD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -28916,16 +29726,13 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/camera/autoname,
-/obj/structure/table/reinforced,
-/obj/item/device/radio/headset{
-	pixel_x = -5
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
 	},
-/obj/item/device/radio/headset,
-/obj/item/device/radio/headset{
-	pixel_x = 5
-	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "qDI" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -28942,6 +29749,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"qEh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "qGg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28961,6 +29775,9 @@
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard_airlock_n)
 "qHZ" = (
@@ -28971,6 +29788,14 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"qIK" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/space)
 "qJt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29001,6 +29826,9 @@
 /obj/machinery/door/airlock/glass_external/public{
 	name = "Docking Arm"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "qSk" = (
@@ -29023,6 +29851,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "qVk" = (
@@ -29040,6 +29869,12 @@
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"qZQ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "rbX" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -29062,6 +29897,9 @@
 /obj/machinery/alarm{
 	frequency = 1441;
 	pixel_y = 22
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
@@ -29098,6 +29936,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"rnz" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "rnI" = (
 /obj/effect/shuttle_landmark/arfs/deck3/dockarm/north,
 /turf/space,
@@ -29129,6 +29977,10 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"rrr" = (
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "rsg" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/tiled/dark,
@@ -29160,6 +30012,9 @@
 	frequency = 1441;
 	pixel_y = 22
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "rKr" = (
@@ -29167,18 +30022,16 @@
 /turf/simulated/floor/airless/ceiling,
 /area/maintenance/engineering)
 "rNP" = (
-/obj/machinery/atmospherics/binary/pump/fuel{
-	dir = 8;
-	name = "Canisters to Tanks"
-	},
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
 /turf/simulated/floor/plating,
-/area/exploration/hanger)
+/area/space)
 "rSR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/wall,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "rST" = (
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control switch for the medbay foyer.";
@@ -29194,8 +30047,13 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 6
 	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "rUg" = (
 /obj/structure/window/reinforced,
 /obj/item/device/radio/headset{
@@ -29211,12 +30069,16 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"rVh" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/space)
 "rVI" = (
 /obj/machinery/vending/loadout/uniform,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "rZO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29239,6 +30101,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "sgl" = (
@@ -29311,14 +30174,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_airlock_s)
-"sJb" = (
-/obj/fiftyspawner/glass,
-/obj/structure/closet/crate{
-	dir = 1
+"sKe" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
 	},
-/obj/fiftyspawner/glass,
-/turf/simulated/floor/plating,
-/area/construction)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "sQD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -29351,26 +30212,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_s)
-"sTE" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
 "sWI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"sXA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "sYs" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
@@ -29456,6 +30318,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_n)
 "tnb" = (
@@ -29502,6 +30367,20 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"tBy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "tFQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29530,6 +30409,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
 "tIs" = (
@@ -29580,11 +30460,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/arrows{
+	dir = 8;
+	color = "#CCCCCC";
+	name = "DARK GRAY floor arrows";
+	pixel_x = 22
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "tTS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -29642,6 +30536,21 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"ucK" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
+"udb" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "udK" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorblack{
@@ -29689,6 +30598,16 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/medical/medbay2)
+"ukG" = (
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Patient Room A";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_kafel/blue/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "unD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/plating,
@@ -29712,12 +30631,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	pixel_y = 25
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/sign/warning/moving_parts{
+	pixel_y = 32
 	},
-/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay/autoresleever)
 "uuA" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass{
@@ -29736,6 +30655,15 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"uxv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "uzq" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_engineeringatmos{
@@ -29766,6 +30694,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_airlock_n)
+"uFe" = (
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 6;
+	tag = "icon-corner_kafel (SOUTHEAST)"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "uGe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29773,6 +30711,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
@@ -29791,6 +30732,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
+"uLa" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
 "uQc" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate{
@@ -29798,6 +30743,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"uQM" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "uQO" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash_pile,
@@ -29841,10 +30803,27 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"vhm" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "vlu" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"vno" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
+"vnM" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "vpj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29896,15 +30875,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
 "vyc" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner_kafel/blue{
-	dir = 5;
-	tag = "icon-corner_kafel (NORTHEAST)"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/fore)
 "vyJ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
@@ -29923,6 +30898,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"vBA" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "vCb" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -29950,8 +30929,13 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"vEY" = (
+/obj/structure/frame,
+/turf/simulated/floor/plating,
+/area/construction)
 "vHH" = (
 /obj/random/trash_pile,
 /obj/structure/catwalk,
@@ -30019,6 +31003,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"vYc" = (
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hallway)
 "vZg" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -30043,6 +31037,7 @@
 	dir = 1;
 	pixel_y = -30
 	},
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "wbL" = (
@@ -30101,6 +31096,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/exploration/hanger)
+"woR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "wpd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30168,6 +31170,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "wzR" = (
@@ -30187,6 +31192,9 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard_airlock_s)
 "wGa" = (
@@ -30204,6 +31212,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"wJd" = (
+/obj/fiftyspawner/steel,
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/plating,
+/area/construction)
 "wJu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -30247,6 +31263,9 @@
 	layer = 3.3;
 	pixel_y = 26
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "wUp" = (
@@ -30271,6 +31290,7 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/green,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "xfj" = (
@@ -30308,6 +31328,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "xmD" = (
@@ -30326,11 +31347,47 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"xrM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
+"xwk" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "xxE" = (
 /obj/machinery/door/window{
 	dir = 2
 	},
 /turf/simulated/floor/tiled/white,
+/area/hallway/station/docking_hall)
+"xAr" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Fore Hallway - Deck 2"
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
 "xBS" = (
 /obj/machinery/power/apc{
@@ -30363,7 +31420,14 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay2)
+"xHi" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/gateway)
 "xHV" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 20
@@ -30385,14 +31449,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
-"xJe" = (
-/obj/fiftyspawner/steel,
-/obj/structure/closet/crate{
-	dir = 1
-	},
-/obj/fiftyspawner/steel,
-/turf/simulated/floor/plating,
-/area/construction)
 "xLK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -30432,6 +31488,10 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall_airlock_n)
+"xOV" = (
+/obj/item/frame,
+/turf/simulated/floor/plating,
+/area/construction)
 "xPf" = (
 /obj/machinery/vending/snack{
 	dir = 1
@@ -30441,6 +31501,16 @@
 "xPn" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"xPF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"xRo" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/space)
 "xSR" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -30453,6 +31523,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"xWC" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/borderfloorblack,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
+"xWS" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall)
 "xXw" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -30483,6 +31565,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"yht" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "yiM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -30499,14 +31587,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
-"yjB" = (
-/obj/fiftyspawner/rods,
-/obj/structure/closet/crate{
-	dir = 2
-	},
-/obj/fiftyspawner/rods,
-/turf/simulated/floor/plating,
-/area/construction)
 "ykV" = (
 /obj/random/maintenance/clean,
 /obj/effect/floor_decal/rust,
@@ -46289,7 +47369,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -46546,7 +47626,7 @@ aaa
 aaa
 aaa
 vCT
-jnM
+gGb
 hBT
 wag
 vCT
@@ -46803,7 +47883,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -47060,7 +48140,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -47319,7 +48399,7 @@ aaa
 eUF
 cTt
 tdW
-vgI
+lma
 eUF
 aaa
 aaa
@@ -47574,7 +48654,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -47831,7 +48911,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 ebl
 jnM
 eUF
@@ -48088,7 +49168,7 @@ aaa
 aaa
 aaa
 vCT
-aLG
+pMX
 hnN
 aLG
 vCT
@@ -48345,7 +49425,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -49373,7 +50453,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -50658,7 +51738,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 mnQ
 eUF
@@ -51172,7 +52252,7 @@ aaa
 aaa
 aaa
 eUF
-exg
+xWS
 tdW
 xjs
 eUF
@@ -51686,7 +52766,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -51943,7 +53023,7 @@ aaa
 aaa
 aaa
 vCT
-aLG
+pMX
 hnN
 aLG
 vCT
@@ -52200,7 +53280,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -52457,7 +53537,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -52971,7 +54051,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 ebl
 jnM
 eUF
@@ -53016,7 +54096,7 @@ aaa
 akL
 aqQ
 avA
-ajj
+xwk
 app
 app
 app
@@ -53228,7 +54308,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -53271,14 +54351,14 @@ aaa
 aaa
 aaa
 akL
-aUl
+dYp
 arb
-ajj
+uQM
 ann
 asz
-aUl
-aUl
-aQu
+mYR
+mYR
+uxv
 prE
 ajm
 ajm
@@ -53485,7 +54565,7 @@ aaa
 aaa
 aaa
 vCT
-jnM
+gGb
 hBT
 wag
 vCT
@@ -53528,7 +54608,7 @@ akL
 akL
 akL
 akL
-aUl
+dYp
 arb
 ajj
 aUl
@@ -53558,7 +54638,7 @@ eus
 aZu
 aZu
 cVW
-bMk
+deI
 uSA
 njQ
 uby
@@ -53742,7 +54822,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -53777,15 +54857,15 @@ aTy
 amY
 afV
 amP
-aUl
-aUl
-aUl
-aUl
+mYR
+mYR
+mYR
+mYR
 ann
-aUl
-aUl
-aUl
-aUl
+mYR
+mYR
+mYR
+jpF
 arb
 ajj
 aUl
@@ -53999,7 +55079,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -54033,7 +55113,7 @@ aWY
 art
 aGg
 aqu
-aOS
+tBy
 aVJ
 aDq
 aDq
@@ -54290,22 +55370,22 @@ axY
 amY
 amY
 afV
-aUl
-aOL
-aUl
-aUl
-aUl
-aUl
-aUl
-aUl
-aUl
-aUl
+dYp
+pjU
+boH
+boH
+boH
+boH
+boH
+boH
+boH
+boH
 aXx
-aUl
-aUl
-aUl
+boH
+boH
+boH
 aRI
-aUl
+boH
 auh
 afV
 aZu
@@ -54547,7 +55627,7 @@ auS
 amY
 avY
 afV
-aUl
+dYp
 aOL
 aUe
 aUe
@@ -54770,7 +55850,7 @@ aaa
 aaa
 aaa
 eUF
-jnM
+gGb
 hBT
 jnM
 eUF
@@ -55027,7 +56107,7 @@ aaa
 aaa
 aaa
 vCT
-jnM
+gGb
 hBT
 jnM
 vCT
@@ -55286,7 +56366,7 @@ vCT
 vCT
 nHZ
 uRI
-nHZ
+eNG
 vCT
 vCT
 vCT
@@ -55318,7 +56398,7 @@ akt
 aSH
 akt
 aqd
-aUl
+dYp
 aOL
 ams
 als
@@ -55540,11 +56620,11 @@ axn
 bXQ
 mDx
 gEp
-jnM
-jnM
+gTC
+bGS
 hBT
-jnM
-jnM
+cYt
+qZQ
 gEp
 pNS
 bXQ
@@ -55575,7 +56655,7 @@ akt
 aSH
 akt
 aqd
-aUl
+dYp
 aOL
 aUe
 aKy
@@ -55797,7 +56877,7 @@ avy
 bXQ
 tUz
 dtu
-jnM
+gGb
 exg
 tdW
 vgI
@@ -55832,7 +56912,7 @@ aRc
 aRc
 aRc
 aqd
-akj
+anN
 alm
 alp
 alw
@@ -56054,7 +57134,7 @@ acD
 bXQ
 dNc
 dtu
-jnM
+gGb
 nMT
 pNL
 tgK
@@ -56311,7 +57391,7 @@ aWd
 bXQ
 grV
 dtu
-jnM
+gGb
 rbX
 eje
 eYL
@@ -56346,7 +57426,7 @@ aRc
 awO
 aRc
 aqd
-aUl
+dYp
 alt
 ams
 axf
@@ -56568,7 +57648,7 @@ aNF
 qOs
 dtu
 dtu
-jnM
+gGb
 cbz
 chi
 xxE
@@ -56603,7 +57683,7 @@ akt
 aIz
 akt
 aqd
-aUl
+dYp
 alt
 ams
 aly
@@ -56825,7 +57905,7 @@ rhZ
 bXQ
 wKh
 dtu
-jnM
+gGb
 iUf
 cMy
 nyd
@@ -57082,7 +58162,7 @@ eNy
 bXQ
 dNc
 dtu
-jnM
+gGb
 vVq
 pNL
 vVq
@@ -57117,7 +58197,7 @@ akt
 aHg
 avl
 aRf
-aUl
+dYp
 alt
 afV
 ahH
@@ -57339,7 +58419,7 @@ lVr
 bXQ
 tUz
 dtu
-jnM
+gGb
 exg
 xXw
 vgI
@@ -57599,8 +58679,8 @@ dtu
 hFS
 lyc
 kva
-jnM
-jnM
+cKb
+iMk
 dtu
 iOU
 bXQ
@@ -57658,11 +58738,11 @@ apx
 aEk
 aEk
 aEk
-aEk
-aEk
+mpv
+uFe
 axu
 aYb
-ape
+pIU
 aqm
 aLb
 anx
@@ -57856,7 +58936,7 @@ syU
 gIE
 bVN
 uRI
-bVN
+xAr
 bXQ
 bXQ
 bXQ
@@ -57908,18 +58988,18 @@ uby
 aqa
 apm
 ici
-aAb
-aAb
-aAb
+atH
+atH
+atH
 aNq
 aEk
 aEk
 aEk
-aEk
-anN
+aYC
+aII
 aCd
 aCd
-aEk
+aJl
 aQW
 aEk
 aEk
@@ -58111,7 +59191,7 @@ jBH
 oVj
 lVs
 syU
-jnM
+gGb
 hBT
 jnM
 bXQ
@@ -58165,7 +59245,7 @@ uby
 aqa
 rZO
 aZu
-aAb
+atH
 olY
 xEm
 aVP
@@ -58176,7 +59256,7 @@ aYC
 aII
 aCd
 aCd
-aTk
+ukG
 aOa
 aOA
 aXq
@@ -58402,7 +59482,7 @@ aVd
 aYX
 aKf
 axT
-aUl
+dYp
 ajM
 ahW
 ahZ
@@ -58422,14 +59502,14 @@ uby
 aqa
 aCQ
 aOh
-aAb
-aUo
+atH
+aJl
 mpv
 aTk
 ayR
 ayR
 ayR
-aOA
+lJu
 aDx
 aDx
 aDx
@@ -58450,9 +59530,9 @@ uby
 nve
 dqf
 hYh
-sYs
+ipT
 oGT
-sYs
+ipT
 hYh
 dqf
 ceP
@@ -58464,13 +59544,13 @@ djz
 djz
 djz
 dpy
-phi
+idR
 djz
 djz
 djz
 djz
 djz
-phi
+idR
 dpy
 jGp
 djz
@@ -58659,7 +59739,7 @@ aAg
 ale
 aqR
 axT
-aUl
+dYp
 ahQ
 ahW
 aia
@@ -58679,14 +59759,14 @@ aZu
 aUq
 bDh
 aZu
-aAb
-vyc
-gGb
-aAb
+atH
+apx
+aYC
+atH
 aGL
 aGL
 aGL
-amT
+aII
 aDx
 aVo
 aVq
@@ -58707,18 +59787,18 @@ ivk
 ceP
 kYg
 hYh
-hbC
+jKy
 aqa
-mKr
+msF
 hYh
-dqf
+iKF
 ceP
 uby
 aZu
 aZu
 bSh
 djz
-djz
+aUo
 djz
 djz
 djz
@@ -58916,7 +59996,7 @@ aiV
 aiV
 aiV
 aiV
-akj
+anN
 ahQ
 ahW
 aib
@@ -58936,9 +60016,9 @@ eus
 aqa
 apm
 uby
-aAb
-aUo
-gGb
+atH
+aJl
+aYC
 aFW
 aRt
 aRt
@@ -58964,9 +60044,9 @@ aZu
 tTX
 dqf
 hYh
-sYs
+ipT
 oGT
-sYs
+ipT
 hYh
 dqf
 ceP
@@ -58978,7 +60058,7 @@ djz
 djz
 djz
 djz
-djz
+blM
 djz
 djz
 djz
@@ -59139,9 +60219,9 @@ bgY
 kME
 hSK
 gIE
-exg
+xWS
 tdW
-vgI
+lma
 bXQ
 oaW
 oaW
@@ -59193,9 +60273,9 @@ aZu
 aqa
 lBb
 gPI
-aAb
-aUo
-gGb
+atH
+aJl
+aYC
 aFW
 aRt
 aRt
@@ -59242,9 +60322,9 @@ djz
 djz
 djz
 djz
+aUo
 djz
-djz
-cWd
+xOV
 cvJ
 bSh
 jJG
@@ -59450,9 +60530,9 @@ gPI
 aqa
 apm
 aZu
-aAb
-aUo
-gGb
+atH
+aJl
+aYC
 aFW
 aRt
 aRt
@@ -59478,7 +60558,7 @@ uby
 vDv
 aqa
 aqa
-kYg
+iKF
 kYg
 dqf
 aqa
@@ -59488,14 +60568,14 @@ aZu
 uby
 uwf
 bSh
-oIx
+pqK
 djz
 djz
 djz
 djz
 djz
 djz
-djz
+pJy
 djz
 djz
 djz
@@ -59688,7 +60768,7 @@ ajb
 ajf
 afV
 ajk
-aUl
+rrr
 ahW
 aie
 aim
@@ -59707,9 +60787,9 @@ aqa
 aqa
 iAc
 aqa
-aAb
-aUo
-gGb
+atH
+aJl
+aYC
 aFW
 aRt
 aRt
@@ -59945,7 +61025,7 @@ ajc
 ajg
 afZ
 ajx
-aUl
+rrr
 ahW
 aif
 aim
@@ -59964,9 +61044,9 @@ aUq
 aZu
 apm
 eus
-aAb
+atH
 fQO
-gGb
+aYC
 aFW
 aRt
 aRt
@@ -60008,7 +61088,7 @@ djz
 djz
 djz
 djz
-djz
+aUo
 djz
 djz
 djz
@@ -60221,9 +61301,9 @@ aqa
 aZu
 mde
 axO
-aAb
-vyc
-gGb
+atH
+apx
+aYC
 aFW
 aRt
 aRt
@@ -60263,16 +61343,16 @@ djz
 djz
 djz
 djz
+kMg
 djz
 djz
 djz
 djz
 djz
+oIc
 djz
 djz
-djz
-djz
-djz
+blM
 djz
 bSh
 fot
@@ -60280,7 +61360,7 @@ jzQ
 uXm
 pkb
 dTp
-plb
+uLa
 aVi
 aVi
 aAM
@@ -60424,9 +61504,9 @@ aWd
 avj
 aNF
 bXQ
-exg
+xWS
 tdW
-vgI
+lma
 bXQ
 pyB
 oaW
@@ -60459,7 +61539,7 @@ ajd
 ajf
 afV
 ahO
-ahT
+xrM
 ahU
 aih
 ain
@@ -60478,7 +61558,7 @@ aqa
 aZu
 dax
 gPI
-aAb
+atH
 lSR
 lJu
 aaw
@@ -60524,7 +61604,7 @@ djz
 djz
 djz
 djz
-djz
+vEY
 djz
 djz
 djz
@@ -60681,7 +61761,7 @@ aWd
 lVr
 aFA
 bXQ
-jnM
+gGb
 hBT
 jnM
 bXQ
@@ -60716,7 +61796,7 @@ ajd
 ajf
 afV
 aFf
-aUl
+rrr
 ahV
 aig
 aig
@@ -60775,10 +61855,10 @@ fEn
 bSh
 djz
 djz
+aUo
 djz
 djz
-djz
-djz
+blM
 djz
 djz
 djz
@@ -60938,7 +62018,7 @@ aWd
 eNy
 aNF
 qOs
-jnM
+gGb
 hBT
 jnM
 qOs
@@ -60973,7 +62053,7 @@ aje
 ajL
 afV
 aFf
-aUl
+rrr
 ahW
 ajT
 aio
@@ -61030,21 +62110,21 @@ aUq
 aqa
 aqa
 bSh
-oIx
+pqK
 djz
 djz
 djz
 djz
 djz
 djz
+qsl
 djz
 djz
 djz
 djz
 djz
 djz
-djz
-msf
+dyd
 bSh
 fot
 jzQ
@@ -61195,7 +62275,7 @@ aWd
 vQN
 aNF
 bXQ
-jnM
+gGb
 hBT
 jnM
 bXQ
@@ -61230,7 +62310,7 @@ aiV
 aiV
 afV
 aFf
-aUl
+rrr
 ahW
 aij
 aio
@@ -61290,8 +62370,8 @@ bSh
 xDs
 djz
 djz
-nzN
-nwg
+laI
+dvO
 djz
 djz
 djz
@@ -61308,7 +62388,7 @@ jzQ
 uXm
 ath
 rKr
-plb
+uLa
 aVi
 atm
 aBZ
@@ -61452,7 +62532,7 @@ aWd
 avy
 aMe
 bXQ
-jnM
+gGb
 hBT
 gBl
 bXQ
@@ -61487,7 +62567,7 @@ hny
 ezH
 afV
 akf
-akj
+xWC
 ahW
 ahX
 aip
@@ -61547,8 +62627,8 @@ bSh
 djz
 djz
 djz
-eJV
-yjB
+dhZ
+eQv
 djz
 djz
 djz
@@ -61556,7 +62636,7 @@ djz
 djz
 djz
 djz
-djz
+aUo
 djz
 djz
 bSh
@@ -61801,13 +62881,13 @@ uJb
 aZu
 axO
 bSh
+blM
 djz
 djz
+eJw
+wJd
 djz
-sJb
-xJe
-djz
-djz
+aUo
 djz
 djz
 djz
@@ -61966,7 +63046,7 @@ aFI
 aNF
 avj
 bXQ
-jnM
+gGb
 hBT
 jnM
 bXQ
@@ -62001,7 +63081,7 @@ duE
 bDp
 afV
 aFf
-aUl
+rrr
 jQv
 uby
 fEn
@@ -62060,7 +63140,7 @@ aqa
 bSh
 djz
 djz
-blM
+xPF
 wcN
 djz
 jDu
@@ -62068,7 +63148,7 @@ ldD
 hwU
 bcc
 mHB
-blM
+xPF
 wcN
 djz
 djz
@@ -62223,7 +63303,7 @@ aYl
 aYl
 aYl
 bXQ
-aLG
+pMX
 hnN
 aLG
 bXQ
@@ -62259,7 +63339,7 @@ aYl
 afV
 ajn
 ajD
-afV
+iFC
 ajF
 ajF
 ajF
@@ -62276,11 +63356,11 @@ ajF
 ajF
 ajF
 aBO
-aAb
+ajF
 mpM
 joA
 hGQ
-aAb
+ajF
 ajF
 ajF
 ajF
@@ -62313,7 +63393,7 @@ aqa
 aqa
 aqa
 wpm
-fef
+hEp
 bSh
 bSh
 bSh
@@ -62336,7 +63416,7 @@ jzQ
 uXm
 pkb
 plb
-plb
+uLa
 aVi
 asG
 aCA
@@ -62441,81 +63521,81 @@ ata
 aWd
 aWJ
 aYl
-aUk
+pGX
 kHW
-aUk
+poS
 aow
-aUk
-aUk
-aUk
+poS
+poS
+poS
 aqJ
 ayM
 aEc
 aYV
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
+poS
+poS
+poS
+poS
+poS
+poS
+poS
 aJA
 aow
-aUk
+poS
 hUc
 ajW
-aUk
-aUk
-aUk
-aUk
+poS
+poS
+poS
+poS
 aJA
-aUk
+poS
 aqJ
 ayM
 aqJ
-aUk
-aUk
-aUk
-aUk
+poS
+poS
+poS
+poS
 aJA
 aow
-aUk
-aUk
+poS
+dNb
 mJT
-aUk
-aUk
-aUk
-aUk
+mTE
+poS
+poS
+poS
 aJA
-aUk
-aUk
-aUk
-aUk
+poS
+poS
+poS
+poS
 aYV
 aqJ
 ayM
 aEc
-aUk
-aUk
-aUk
-aUk
+poS
+poS
+poS
+poS
 eWg
-aUk
+poS
 aJA
-aUk
+poS
 aow
-aUk
+poS
 bOs
-aUk
-aUk
-aUk
+poS
+poS
+poS
 aJA
-aUk
+poS
 aqJ
 avJ
-aUl
-aFf
-aUl
+mYR
+hpH
+vnM
 oJO
 aIj
 apw
@@ -62561,16 +63641,16 @@ apC
 aZb
 apC
 apC
-ioJ
+kpu
 mRx
 ppc
 gfR
 gfR
 gfR
 gfR
-sTE
-olx
-lQw
+cLv
+lNg
+udb
 meR
 rzy
 fbG
@@ -62829,13 +63909,13 @@ aKB
 aKB
 aKB
 aTQ
-aYN
+lch
 lOs
-aYN
-aYN
-aYN
-aYN
-aYN
+lch
+lch
+lch
+lch
+lch
 vXl
 aBx
 aBH
@@ -62957,79 +64037,79 @@ aKX
 aYl
 aSL
 aBi
-aUk
-aSL
-aUk
-aUk
-aUk
-aTb
-ayM
+vyc
+eFT
+vyc
+vyc
+vyc
+cOT
+fLC
 aHU
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
+vyc
+vyc
+vyc
+vyc
+vyc
+vyc
+vyc
+vyc
+vyc
 aBi
-aUk
-aUk
-aUk
+vyc
+vyc
+vyc
 aEi
-aUk
-aUk
-aUk
-aUk
-aUk
+vyc
+vyc
+vyc
+vyc
+vyc
 aHU
-ayM
+fLC
 aTb
 cmR
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
+vno
+vyc
+vyc
+vyc
+vyc
+vyc
+vyc
 aBi
-aUk
-aUk
+vyc
+vyc
 ajZ
+vyc
+vyc
+vyc
+iOC
 aUk
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
-aTb
-ayM
-aTb
-aUk
-aUk
+vno
+vyc
+cOT
+fLC
+cOT
+vyc
+vyc
 ajZ
-aUk
-aUk
-aUk
-aUk
-aUk
+vyc
+vyc
+vyc
+vyc
+vyc
 aBi
-aUk
-aUk
-aUk
-aUk
-aUk
-aUk
+vyc
+vyc
+vyc
+vyc
+vyc
+vyc
 aIF
 aHU
-avJ
-aUl
-ajj
-aUl
+cJe
+boH
+feE
+doZ
 eAM
 uuA
 aYz
@@ -63245,7 +64325,7 @@ aYl
 jDb
 eSR
 mIh
-eSR
+crC
 jDb
 aYl
 aYl
@@ -63260,7 +64340,7 @@ aYl
 aYl
 aYl
 pff
-ayM
+jtf
 ibI
 aYl
 aYl
@@ -63286,8 +64366,8 @@ aYl
 aYl
 afV
 aCl
-aUl
-afV
+rrr
+elD
 ajF
 ajF
 ajF
@@ -63346,6 +64426,7 @@ qzE
 ajF
 ajF
 ajF
+kqO
 ajF
 ajF
 ajF
@@ -63357,8 +64438,7 @@ ajF
 ajF
 ajF
 ajF
-ajF
-ajF
+kqO
 ajF
 ajF
 ajF
@@ -63366,7 +64446,7 @@ axA
 aGj
 aNJ
 aEn
-rNP
+aKe
 aKe
 aFv
 alc
@@ -63500,9 +64580,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -63516,9 +64596,9 @@ aoo
 aoo
 aoo
 aYl
+kzK
 aUk
-aUk
-aUk
+mTE
 jwM
 sgl
 sgl
@@ -63542,8 +64622,8 @@ aoo
 aoo
 aoo
 afV
-ajj
-aUl
+aYN
+rrr
 afV
 aoo
 aoo
@@ -63601,24 +64681,24 @@ oHr
 rlg
 dBB
 aRs
+eQK
+rNP
+eJV
+oOY
+aRs
+rVh
+buO
 aIm
 aIm
+ous
 aIm
+eJV
 aIm
+buO
+rNP
+eJV
 aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
+qIK
 aFv
 aGj
 unD
@@ -63757,9 +64837,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 jLU
-mdY
+phi
 wUI
 aoo
 aoo
@@ -63858,24 +64938,24 @@ aRs
 aRs
 aRs
 aRs
+xRo
+aIm
+eJV
+buO
+neC
+aIm
+eJV
+aIm
+aRs
+aRs
+aRs
+aRs
+aRs
 aIm
 aIm
 aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
+rNP
+bsn
 aFv
 aGj
 unD
@@ -64030,9 +65110,9 @@ aoo
 aoo
 aoo
 aYl
-aUk
-aUk
-aUk
+pCY
+vyc
+vyc
 sgl
 sgl
 sgl
@@ -64112,27 +65192,27 @@ awK
 aJb
 asX
 aIm
+eJV
+ous
 aIm
+buO
 aIm
+jjp
 aIm
+aRs
+eJV
+buO
+bsn
+aRs
+kCy
+oIZ
+aXv
+aRs
+rVh
+vhm
+gcY
 aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
-aIm
+eJV
 aFv
 aGj
 aSw
@@ -64271,9 +65351,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 roj
-mdY
+phi
 wUI
 aoo
 aoo
@@ -64528,9 +65608,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -64785,7 +65865,7 @@ aoo
 aoo
 aoo
 jDb
-mdY
+qin
 tUT
 pCT
 jDb
@@ -65042,9 +66122,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -65299,9 +66379,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -65558,7 +66638,7 @@ aoo
 wUI
 rgd
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -66070,9 +67150,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -66327,9 +67407,9 @@ aoo
 aoo
 aoo
 jDb
-mdY
+qin
 tUT
-mdY
+phi
 jDb
 aoo
 aoo
@@ -66586,7 +67666,7 @@ aoo
 jDb
 eSR
 mIh
-eSR
+crC
 jDb
 aoo
 aoo
@@ -66841,9 +67921,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -67098,9 +68178,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -67612,9 +68692,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 roj
-mdY
+phi
 wUI
 aoo
 aoo
@@ -67869,9 +68949,9 @@ aGr
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -68126,7 +69206,7 @@ aGr
 aoo
 aoo
 jDb
-mdY
+qin
 tUT
 pCT
 jDb
@@ -68383,9 +69463,9 @@ aGr
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -68640,9 +69720,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -68899,7 +69979,7 @@ aoo
 wUI
 rgd
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -69231,22 +70311,22 @@ aRC
 aQj
 aPP
 aWn
+fmT
+aWn
+aWn
+aWn
+aWn
+amT
+aWn
+aWn
+rnz
 aWn
 aWn
 aWn
 aWn
 aWn
-aWn
-aWn
-aWn
-aWn
-aWn
-aWn
-aWn
-aWn
-aWn
-aWn
-aWn
+amT
+rnz
 axR
 feL
 aXJ
@@ -69411,9 +70491,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 afu
@@ -69488,12 +70568,12 @@ acJ
 aHr
 aHc
 aGJ
+jZP
 aGJ
 aGJ
 aGJ
 aGJ
-aGJ
-aGJ
+jZP
 aGJ
 aGJ
 aGJ
@@ -69502,7 +70582,7 @@ aNR
 aGJ
 aGJ
 aGJ
-aGJ
+jZP
 aGJ
 all
 axd
@@ -69668,9 +70748,9 @@ aoo
 aoo
 aoo
 jDb
-mdY
+qin
 tUT
-mdY
+phi
 jDb
 aoo
 afu
@@ -69745,12 +70825,12 @@ aRC
 aRC
 aPP
 aMl
-anm
+ooX
 anm
 aOy
 anm
 anm
-anm
+fqu
 anm
 aMl
 aOy
@@ -69759,8 +70839,8 @@ aRB
 aWE
 aOy
 anm
-anm
-anm
+fqu
+vYc
 bcx
 mER
 aXJ
@@ -69927,7 +71007,7 @@ aoo
 jDb
 eSR
 mIh
-eSR
+crC
 jDb
 aoo
 afu
@@ -70182,9 +71262,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 afu
@@ -70266,11 +71346,11 @@ aoo
 aMG
 aFo
 aIM
-aIM
+xHi
 aIM
 aIM
 ajr
-aIM
+kZT
 aDa
 aMG
 aoo
@@ -70439,9 +71519,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 afu
@@ -70782,9 +71862,9 @@ aXR
 ask
 ask
 ask
-ask
+oYz
 awp
-aIM
+aSh
 aZB
 aMG
 aoo
@@ -70953,9 +72033,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 roj
-mdY
+phi
 wUI
 aoo
 aoo
@@ -71210,9 +72290,9 @@ aoo
 aoo
 aoo
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aoo
 aoo
@@ -71467,7 +72547,7 @@ aoo
 aoo
 aoo
 jDb
-mdY
+qin
 tUT
 pCT
 jDb
@@ -71724,9 +72804,9 @@ aoo
 aoo
 aaa
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -71981,9 +73061,9 @@ aoo
 aoo
 aaa
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -72240,7 +73320,7 @@ aaa
 jDb
 eSR
 mIh
-eSR
+crC
 jDb
 aaa
 aaa
@@ -72495,9 +73575,9 @@ aaa
 aaa
 aaa
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -72752,9 +73832,9 @@ aaa
 aaa
 aaa
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -73266,9 +74346,9 @@ aaa
 aaa
 aaa
 wUI
-mdY
+qin
 roj
-mdY
+phi
 wUI
 aaa
 aaa
@@ -73523,9 +74603,9 @@ aaa
 aaa
 aaa
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -73780,7 +74860,7 @@ aaa
 aaa
 aaa
 jDb
-mdY
+qin
 tUT
 pCT
 jDb
@@ -74037,9 +75117,9 @@ aaa
 aaa
 aaa
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -74294,9 +75374,9 @@ aaa
 aaa
 aaa
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -74551,7 +75631,7 @@ jDb
 jDb
 jDb
 jDb
-eNF
+iNC
 fGb
 eNF
 jDb
@@ -74807,11 +75887,11 @@ aaa
 elk
 fcK
 kIT
-mdY
-mdY
+dtn
+lId
 tUT
-mdY
-mdY
+loQ
+hGc
 kIT
 bYH
 elk
@@ -75064,11 +76144,11 @@ aaa
 elk
 eiU
 ney
-mdY
+qin
 eoz
 ivM
 vfP
-mdY
+phi
 ney
 wXo
 elk
@@ -75321,11 +76401,11 @@ aaa
 elk
 fiQ
 ney
-mdY
+qin
 fiI
 vtU
 evk
-mdY
+phi
 ney
 kOJ
 elk
@@ -75578,11 +76658,11 @@ aaa
 elk
 ooq
 ney
-mdY
+qin
 hph
 tnb
 rUg
-mdY
+phi
 ney
 unR
 elk
@@ -75835,11 +76915,11 @@ aaa
 elk
 ney
 ney
-mdY
+qin
 lkc
 qoK
 qLp
-mdY
+phi
 ney
 ney
 elk
@@ -76092,11 +77172,11 @@ aaa
 elk
 xDy
 ney
-mdY
+qin
 sSd
 cCL
 eoA
-mdY
+phi
 ney
 pbr
 elk
@@ -76349,11 +77429,11 @@ aaa
 elk
 fiQ
 ney
-mdY
+qin
 tOa
 vtU
 tOa
-mdY
+phi
 ney
 hKe
 elk
@@ -76606,11 +77686,11 @@ aaa
 elk
 eiU
 ney
-mdY
+qin
 eoz
 wOd
 vfP
-mdY
+phi
 ney
 wXo
 elk
@@ -76864,10 +77944,10 @@ elk
 bsG
 ney
 nLU
-fZO
+sXA
 fAD
-mdY
-mdY
+vBA
+yht
 ney
 xPf
 elk
@@ -77123,7 +78203,7 @@ dbS
 cFi
 qQF
 fGb
-qQF
+ouw
 elk
 elk
 elk
@@ -77378,9 +78458,9 @@ hIV
 uBe
 kdo
 dbS
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -77635,9 +78715,9 @@ qhe
 hCk
 wNJ
 dbS
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -77892,7 +78972,7 @@ xHV
 eGa
 oqc
 dbS
-mdY
+qin
 tUT
 eRl
 jDb
@@ -78149,7 +79229,7 @@ hqF
 iwY
 bDz
 tAN
-eoz
+qEh
 ivM
 tHY
 wUI
@@ -78406,9 +79486,9 @@ iig
 iwY
 qhe
 cFi
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -78922,7 +80002,7 @@ cFi
 cFi
 eSR
 mIh
-eSR
+crC
 jDb
 aaa
 aaa
@@ -79177,9 +80257,9 @@ aaa
 aaa
 aaa
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -79436,7 +80516,7 @@ aaa
 wUI
 rgd
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -79950,7 +81030,7 @@ aaa
 wUI
 gDn
 tUT
-mdY
+phi
 wUI
 aaa
 aaa
@@ -80205,9 +81285,9 @@ aaa
 wUI
 wUI
 wUI
-mdY
+qin
 tUT
-mdY
+phi
 wUI
 wUI
 wUI
@@ -80462,9 +81542,9 @@ pjZ
 pjZ
 qGA
 oAu
-oAu
+eQs
 ovw
-oAu
+woR
 oAu
 wFO
 tZp
@@ -81232,11 +82312,11 @@ xPn
 fUi
 xPn
 gpP
-mdY
-mdY
+ucK
+sKe
 kof
-mdY
-mdY
+vBA
+ucK
 aHC
 ndN
 mUq
@@ -81490,7 +82570,7 @@ aaa
 wUI
 wUI
 wUI
-mdY
+qin
 kof
 pAv
 wUI
@@ -81749,7 +82829,7 @@ aaa
 wUI
 rgd
 kof
-mdY
+phi
 wUI
 aaa
 aaa
@@ -82004,7 +83084,7 @@ aaa
 aaa
 aaa
 wUI
-eoz
+qEh
 kyE
 tHY
 wUI
@@ -82263,7 +83343,7 @@ aaa
 wUI
 gDn
 mdY
-mdY
+phi
 wUI
 aaa
 aaa

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -3957,12 +3957,10 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 1
 	},
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/structure/disposalpipe/down{
 	dir = 1
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/station/micro)
 "ahO" = (
@@ -4568,6 +4566,12 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "aji" = (
@@ -4626,27 +4630,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/central)
 "ajm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
+/turf/simulated/wall/r_wall,
+/area/maintenance/medbay_aft)
 "ajn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4775,13 +4760,9 @@
 /turf/simulated/floor/wood,
 /area/library)
 "ajC" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/central)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "ajD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -5154,8 +5135,14 @@
 /area/exploration/hanger)
 "akx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/machinery/door/window/southleft{
+	req_one_access = list(11,24);
+	name = "Ship Thrusters"
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
 "aky" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -5225,12 +5212,15 @@
 	name = "\improper Research Upper Hallway"
 	})
 "akE" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/window/southright{
+	req_one_access = list(11,24);
+	name = "Ship Thrusters"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
 "akF" = (
 /obj/machinery/computer/ship/engines/adv,
@@ -5260,6 +5250,12 @@
 "akI" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -5487,6 +5483,10 @@
 	},
 /obj/structure/lattice,
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
 /turf/simulated/open,
 /area/engineering/thrusters)
 "ald" = (
@@ -5901,11 +5901,11 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "alT" = (
-/obj/structure/catwalk,
-/obj/machinery/alarm/angled/hidden{
-	pixel_y = 26
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
 "alU" = (
 /obj/effect/floor_decal/techfloor{
@@ -6831,6 +6831,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "anT" = (
@@ -7554,7 +7560,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/catwalk,
 /obj/machinery/light_switch{
 	dir = 4;
 	on = 0;
@@ -7612,6 +7617,12 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "apx" = (
@@ -7654,8 +7665,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hallway)
 "apC" = (
-/obj/machinery/camera/autoname{
-	dir = 5
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -7890,7 +7904,8 @@
 /obj/machinery/vending/fishing,
 /obj/machinery/light{
 	dir = 8;
-	light_color = "#edb02d"
+	light_color = "#edb02d";
+	name = "dim light fixture"
 	},
 /turf/simulated/floor/grass,
 /area/crew_quarters/longue_area)
@@ -7957,13 +7972,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
 "aqf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aqg" = (
@@ -8853,7 +8867,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/exploration/gear)
 "arN" = (
-/obj/structure/catwalk,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_x = 28
+	},
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "arO" = (
@@ -9597,13 +9616,8 @@
 /turf/simulated/floor/plating,
 /area/ai/outside)
 "ath" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay_aft)
+/turf/simulated/wall,
+/area/maintenance/engineering)
 "ati" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10641,7 +10655,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "auV" = (
@@ -11145,7 +11158,8 @@
 "avS" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_research{
-	req_one_access = list(19,43,67,68,69)
+	req_one_access = list(19,43,67,68,69);
+	name = "Fuel Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -11303,7 +11317,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "awj" = (
@@ -11399,7 +11412,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 8
 	},
@@ -12141,6 +12153,12 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "axI" = (
@@ -12236,20 +12254,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
 "axO" = (
-/obj/effect/floor_decal/corner_kafel/blue{
-	dir = 6;
-	tag = "icon-corner_kafel (SOUTHEAST)"
-	},
-/obj/effect/floor_decal/corner_kafel/blue{
-	dir = 5;
-	tag = "icon-corner_kafel (NORTHEAST)"
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Patient Room A";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "axP" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
@@ -12799,7 +12806,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
@@ -12939,7 +12945,6 @@
 /area/maintenance/research_starboard)
 "azg" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -13775,16 +13780,9 @@
 	},
 /area/shuttle/excursion/cargo)
 "aAH" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/engineering/thrusters)
+/area/maintenance/engineering)
 "aAI" = (
 /turf/simulated/open,
 /area/security/security_cell_hallway)
@@ -13823,18 +13821,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/obj/machinery/camera/autoname,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aAN" = (
@@ -14192,6 +14190,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "aBy" = (
@@ -14322,6 +14325,11 @@
 "aBH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "aBI" = (
@@ -14356,7 +14364,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -14379,6 +14386,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -14408,7 +14421,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -14524,7 +14536,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14741,7 +14752,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -14757,7 +14767,6 @@
 /area/maintenance/security_port)
 "aCr" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14831,7 +14840,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14865,7 +14873,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aCB" = (
@@ -14970,7 +14977,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aCM" = (
@@ -15053,6 +15059,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
 "aCR" = (
@@ -15420,7 +15427,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/locker/upper/room2)
 "aDD" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -15431,7 +15437,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aDE" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -15473,16 +15478,12 @@
 /obj/fiftyspawner/phoron,
 /obj/fiftyspawner/phoron,
 /obj/structure/closet/crate,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aDJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/engineering/thrusters)
+/obj/random/trash,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "aDK" = (
 /obj/item/device/flashlight/lantern,
 /obj/effect/floor_decal/chapel,
@@ -15502,12 +15503,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aDN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/obj/machinery/portable_atmospherics/canister/phoron,
 /obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
@@ -15558,7 +15557,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aDU" = (
@@ -15591,7 +15589,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aDY" = (
@@ -15614,9 +15611,18 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
 "aEa" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/plating,
-/area/engineering/thrusters)
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "aEb" = (
 /turf/simulated/wall,
 /area/security/security_cell_hallway)
@@ -15691,7 +15697,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aEk" = (
@@ -15744,20 +15749,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "aEp" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/thrusters)
+/turf/simulated/open,
+/area/medical/medbay)
 "aEq" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -15787,7 +15783,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aEs" = (
@@ -15801,9 +15796,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/exploration/gear)
 "aEt" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15815,7 +15807,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
 "aEu" = (
@@ -15843,6 +15837,12 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -15884,12 +15884,14 @@
 /area/exploration/gear)
 "aEA" = (
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
 /turf/simulated/open,
 /area/engineering/thrusters)
 "aEB" = (
 /obj/structure/ladder,
-/obj/structure/railing/grey{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
 	},
 /turf/simulated/floor/plating,
 /area/engineering/thrusters)
@@ -15901,7 +15903,8 @@
 /obj/structure/flora/ausbushes/genericbush,
 /obj/machinery/light{
 	dir = 8;
-	light_color = "#edb02d"
+	light_color = "#edb02d";
+	name = "dim light fixture"
 	},
 /turf/simulated/floor/grass,
 /area/crew_quarters/longue_area)
@@ -17329,6 +17332,12 @@
 /obj/machinery/door/airlock/glass{
 	name = "Aft Hallway - Deck 2"
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "aIk" = (
@@ -18294,10 +18303,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
 "aKt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -18308,6 +18313,14 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -18878,6 +18891,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "aLz" = (
@@ -18914,6 +18933,12 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "aLE" = (
@@ -18929,6 +18954,13 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"aLH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
 "aLI" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
@@ -20358,7 +20390,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai/outside)
 "aPo" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/chapel/main)
 "aPp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -21117,6 +21149,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -22452,17 +22490,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
 "aUo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 5;
+	tag = "icon-corner_kafel (NORTHEAST)"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "aUq" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
-/area/exterior/deckthree)
+/area/maintenance/medbay_aft)
 "aUr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22592,6 +22630,12 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -23926,6 +23970,12 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "aXR" = (
@@ -24202,6 +24252,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "aYA" = (
@@ -24296,8 +24352,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aYN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "aYO" = (
@@ -24391,6 +24453,12 @@
 "aZb" = (
 /obj/structure/sign/deck/third{
 	pixel_x = -29
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -24607,6 +24675,12 @@
 "aZC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -25044,6 +25118,15 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"bcc" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/construction)
 "bcx" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 6
@@ -25061,6 +25144,12 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"bhI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "bhR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/firealarm{
@@ -25085,6 +25174,32 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"blM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"bmh" = (
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/exploration/hanger)
+"boS" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 28;
+	tag = "icon-extinguisher_closed (WEST)"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "brc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
@@ -25119,6 +25234,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
+"bDh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "bDp" = (
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
@@ -25127,6 +25260,13 @@
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"bEB" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "bJT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -25142,6 +25282,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"bMk" = (
+/obj/structure/barricade/planks,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"bOm" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/southleft,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "bOs" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -25150,6 +25302,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
+"bSh" = (
+/turf/simulated/wall/r_wall,
+/area/construction)
 "bSj" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -25179,6 +25334,10 @@
 "bXQ" = (
 /turf/simulated/wall,
 /area/hallway/station/docking_hall)
+"bYw" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "bYH" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/material/ashtray/glass,
@@ -25191,6 +25350,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall)
+"cbG" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
+"cbP" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
 "ccC" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -25206,6 +25376,9 @@
 /obj/effect/shuttle_landmark/arfs/deck3/space/nw,
 /turf/space,
 /area/space)
+"ceP" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "chi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25266,6 +25439,12 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"cvJ" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "cvS" = (
 /obj/machinery/airlock_sensor{
 	pixel_x = 25
@@ -25278,6 +25457,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"cwX" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "cAl" = (
 /obj/machinery/light{
 	dir = 1
@@ -25323,6 +25506,22 @@
 "cFi" = (
 /turf/simulated/wall,
 /area/security/checkpoint/starboard)
+"cFE" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
+"cGW" = (
+/obj/random/maintenance/clean,
+/obj/structure/closet/crate,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "cMy" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -25364,6 +25563,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_s)
+"cRo" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/railing/grey,
+/obj/machinery/vending/engivend,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
 "cTt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -25386,10 +25593,38 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"cVW" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"cWd" = (
+/obj/item/frame,
+/turf/simulated/floor/plating,
+/area/construction)
 "cXq" = (
 /obj/effect/shuttle_landmark/arfs/deck3/dockarm/south/starboard,
 /turf/space,
 /area/space)
+"dax" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "dbS" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/glass,
@@ -25402,6 +25637,48 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"dfo" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"dgI" = (
+/obj/machinery/transhuman/autoresleever,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"djz" = (
+/turf/simulated/floor/plating,
+/area/construction)
+"dkj" = (
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
+"doV" = (
+/obj/random/junk,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
+"dpy" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"dqf" = (
+/obj/structure/table/reinforced,
+/obj/random/maintenance/foodstuff,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "dtu" = (
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
@@ -25409,6 +25686,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"dBB" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/space)
 "dKe" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -25417,6 +25700,21 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"dKm" = (
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/exploration/hanger)
+"dKX" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "dNc" = (
 /obj/structure/bed/chair/bay,
 /turf/simulated/floor/carpet,
@@ -25458,16 +25756,39 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_w)
+"dTp" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
 "dVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"dXC" = (
+/obj/random/maintenance/clean,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "dZs" = (
 /obj/structure/bed/chair/bay/comfy,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"ebj" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	name = "Autoresleeving Lab";
+	id_tag = "AutoResleeverDoor"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "ebl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25483,6 +25804,43 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"eeo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
+"ehV" = (
+/obj/structure/sign/deck/third{
+	pixel_x = -29
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "eiU" = (
 /obj/machinery/light{
 	dir = 1
@@ -25513,6 +25871,28 @@
 "elk" = (
 /turf/simulated/wall,
 /area/hallway/station/docking_hall_starboard)
+"emY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"enG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "eoz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -25533,10 +25913,29 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall_starboard)
+"esT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "eug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"eus" = (
+/obj/random/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"euS" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "evk" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/radio/headset{
@@ -25573,6 +25972,15 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"eAM" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "eBP" = (
 /obj/structure/closet/crate{
 	dir = 1
@@ -25588,6 +25996,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"eJV" = (
+/obj/fiftyspawner/plastic,
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/fiftyspawner/plastic,
+/turf/simulated/floor/plating,
+/area/construction)
+"eKj" = (
+/obj/machinery/camera/autoname,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
+"eNs" = (
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "eNy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -25625,6 +26049,13 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"eRl" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "eSR" = (
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
@@ -25633,6 +26064,13 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall)
+"eUV" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "eVj" = (
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
@@ -25670,6 +26108,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard_airlock_s)
+"fbG" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "fcK" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/material/ashtray/glass,
@@ -25695,6 +26143,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"fef" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "feL" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 9
@@ -25725,6 +26182,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"ffX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/plating,
+/area/exploration/hanger)
 "fib" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -25755,6 +26216,58 @@
 /obj/structure/bed/chair/bay,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
+"fot" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"frr" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
+"ftC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"fwq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"fwB" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/engineering{
+	name = "Thrusters Access";
+	req_one_access = list(11,24)
+	},
+/turf/simulated/floor/plating,
+/area/exploration/hanger)
 "fAD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25780,6 +26293,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"fBd" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/thrusters)
+"fBL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"fEn" = (
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"fFt" = (
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "fGb" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/glass,
@@ -25796,10 +26336,36 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall_starboard)
+"fQO" = (
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 5;
+	tag = "icon-corner_kafel (NORTHEAST)"
+	},
+/obj/machinery/camera/autoname,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"fQP" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
 "fUi" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"fUl" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "fXi" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -25816,6 +26382,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"gfR" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"gig" = (
+/obj/random/maintenance/clean,
+/obj/effect/floor_decal/rust,
+/obj/structure/closet/crate,
+/obj/random/junk,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"gkm" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "gpP" = (
 /obj/machinery/light{
 	dir = 1
@@ -25840,6 +26432,23 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"gzO" = (
+/obj/machinery/vending/tool,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
+"gAD" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "gBl" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -25865,6 +26474,13 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"gGb" = (
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 10;
+	tag = "icon-corner_kafel (SOUTHWEST)"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "gHu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25922,12 +26538,48 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"gPI" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"gTR" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 1;
+	tag = "icon-bordercolorcorner (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"gVo" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "gWu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"hbC" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "hbP" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -25957,6 +26609,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"hno" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "hny" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -26024,6 +26685,28 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/excursion/medical)
+"hwU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"hyx" = (
+/obj/random/trash_pile,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "hBT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26089,6 +26772,25 @@
 /obj/random/pottedplant,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"hGQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"hHb" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/random/trash,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "hIV" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/light{
@@ -26122,6 +26824,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_n)
+"hQv" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
 "hSK" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
@@ -26129,6 +26842,21 @@
 /obj/effect/shuttle_landmark/arfs/deck3/dockarm/north/starboard,
 /turf/space,
 /area/space)
+"hTO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "hUc" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -26137,6 +26865,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
+"hWP" = (
+/obj/machinery/door/airlock/medical{
+	name = "Autoresleeving Lab"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "hXb" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/sec,
@@ -26154,6 +26889,10 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_s)
+"hYh" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "ibI" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/sign/directions/stairs_down{
@@ -26161,6 +26900,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
+"ici" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "ihu" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -26178,10 +26922,34 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"ijk" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"inm" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"ioJ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "iuR" = (
 /obj/machinery/light,
 /turf/simulated/open,
 /area/hallway/primary/deckthree/fore)
+"ivk" = (
+/obj/random/maintenance/clean,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "ivM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -26194,6 +26962,41 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"ivP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"ivY" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "iwz" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window{
@@ -26207,6 +27010,21 @@
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"iwQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "iwY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26221,6 +27039,29 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"iAc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"iAA" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "iGa" = (
 /obj/machinery/door/airlock/angled_tgmc{
 	dir = 4;
@@ -26235,6 +27076,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"iLs" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "iNh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -26256,6 +27101,16 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"iQh" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"iQz" = (
+/obj/random/junk,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
 "iUf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -26298,9 +27153,34 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"jio" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/purple/bordercorner,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"jmh" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "jnM" = (
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"joA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "jpN" = (
 /obj/machinery/light,
 /obj/effect/map_helper/airlock/sensor/int_sensor,
@@ -26361,6 +27241,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"jzQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "jBH" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/light{
@@ -26371,9 +27265,52 @@
 "jDb" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard)
+"jDu" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "jFU" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_airlock_n)
+"jGp" = (
+/obj/machinery/floodlight{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"jGD" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_engineeringatmos{
+	name = "Construction Site";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"jJG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "jKo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26395,6 +27332,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"jQv" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/hallway/primary/deckthree/central)
 "jTS" = (
 /obj/effect/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/airlock_sensor{
@@ -26403,6 +27345,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_w)
+"jWE" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "jXW" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -26411,6 +27359,14 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"jZq" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northright,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "kaU" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
@@ -26444,6 +27400,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"kdO" = (
+/obj/random/maintenance/engineering,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"kjd" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"knz" = (
+/obj/random/maintenance/engineering,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
 "kof" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26460,6 +27432,17 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"kqO" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/hallway/primary/deckthree/aft)
+"kuk" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "kva" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26479,6 +27462,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"kvk" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "kwG" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/dark,
@@ -26503,6 +27498,17 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"kHG" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/thrusters)
 "kHW" = (
 /obj/machinery/light{
 	dir = 8
@@ -26535,6 +27541,24 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
+"kPp" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"kYg" = (
+/obj/structure/table/reinforced,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "lcT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/firealarm{
@@ -26543,6 +27567,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"ldD" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "lfI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
@@ -26574,11 +27605,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"loy" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "ltj" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	pixel_x = -27;
 	tag = "icon-extinguisher_closed (EAST)"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -26605,6 +27649,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
+"lvN" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "lyc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26613,6 +27667,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"lBb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "lDX" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/carpet,
@@ -26631,6 +27703,57 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"lJu" = (
+/obj/effect/floor_decal/corner_kafel/blue/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"lMN" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"lOs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"lOX" = (
+/obj/structure/railing,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
+"lPe" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"lQw" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"lSR" = (
+/obj/effect/floor_decal/corner_kafel/blue/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "lVr" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -26648,9 +27771,57 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"lVx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
+"mde" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "mdY" = (
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"meR" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"mfJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"mgQ" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "mkX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -26678,6 +27849,47 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"mpd" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"mpv" = (
+/obj/effect/floor_decal/corner_kafel/blue,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"mpM" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/wall{
+	dir = 4;
+	name = "auto-resleeving equipment deposit"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"mqc" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
+"msf" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/construction)
 "msj" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -26696,14 +27908,31 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"mxL" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "mxO" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_airlock_s)
+"mzZ" = (
+/obj/machinery/light/small,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "mAz" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	pixel_x = -28;
 	tag = "icon-extinguisher_closed (EAST)"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -26739,6 +27968,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hallway)
+"mHB" = (
+/obj/machinery/floodlight{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 28;
+	tag = "icon-extinguisher_closed (WEST)"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "mId" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -26777,6 +28017,17 @@
 /area/crew_quarters/sleep{
 	name = "\improper Ball Room"
 	})
+"mKr" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "mMq" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -26790,6 +28041,25 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_n)
+"mRx" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"mTh" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "mTx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -26804,6 +28074,15 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hanger)
+"naQ" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = -5
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "ndN" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard_airlock_s)
@@ -26817,6 +28096,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"nhQ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
 "njf" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -26826,6 +28109,11 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"njQ" = (
+/obj/random/junk,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "nlM" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -26839,6 +28127,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_s)
+"nve" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
+"nwg" = (
+/obj/item/weapon/rcd,
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "nwy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -26866,6 +28165,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall)
+"nzN" = (
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/item/weapon/pipe_dispenser,
+/turf/simulated/floor/plating,
+/area/construction)
 "nDX" = (
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/airlock_sensor{
@@ -26983,9 +28289,57 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"nWL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "oaW" = (
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"obj" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
+"odu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"odW" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"ogf" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "ojX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -26997,6 +28351,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"olx" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 1;
+	tag = "icon-bordercolorcorner (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"olY" = (
+/obj/effect/floor_decal/corner_kafel/blue/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"omH" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "oon" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -27026,11 +28406,35 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"ort" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "otx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"oua" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"ouH" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "ovw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -27054,6 +28458,39 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"oCh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"oGT" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/foodstuff,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"oHr" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/wood,
+/area/space)
+"oIx" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"oJO" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "oLi" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -27088,6 +28525,13 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"paK" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "paY" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -27123,14 +28567,60 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
+"phi" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "pjZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"pkb" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
+"plb" = (
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
+"plU" = (
+/obj/structure/grille/broken,
+/obj/item/weapon/tool/wirecutters,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"pmr" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
+"ppc" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"prE" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/primary/deckthree/central)
 "puk" = (
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"pvJ" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "pyf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27153,6 +28643,19 @@
 /obj/effect/shuttle_landmark/arfs/deck3/space/sw,
 /turf/space,
 /area/space)
+"pBI" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "pBU" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -27172,6 +28675,33 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"pFn" = (
+/obj/structure/table/rack/steel,
+/obj/structure/catwalk,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
+"pFJ" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
+"pGC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
+"pKZ" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "pND" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -27210,6 +28740,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/deckthree/fore)
+"pRm" = (
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "pVz" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/sec,
@@ -27225,6 +28764,23 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_n)
+"qbw" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"qfU" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/station/docking_hall_starboard)
 "qgJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -27252,6 +28808,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"qoE" = (
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "qoH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -27292,6 +28857,9 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"qsL" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/engineering)
 "qxq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -27309,6 +28877,55 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"qzg" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"qzD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"qzE" = (
+/turf/simulated/floor/wood,
+/area/hallway/primary/deckthree/aft)
+"qBu" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/camera/autoname,
+/obj/structure/table/reinforced,
+/obj/item/device/radio/headset{
+	pixel_x = -5
+	},
+/obj/item/device/radio/headset,
+/obj/item/device/radio/headset{
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "qDI" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -27354,6 +28971,15 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"qJt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "qLp" = (
 /obj/machinery/door/window{
 	dir = 2
@@ -27377,6 +29003,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"qSk" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "qTC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -27387,6 +29025,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"qVk" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "qXe" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 20
@@ -27424,6 +29069,11 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"rlg" = (
+/obj/structure/table/woodentable,
+/obj/random/maintenance/foodstuff,
+/turf/simulated/floor/wood,
+/area/space)
 "rlq" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -27436,6 +29086,18 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"rlZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "rnI" = (
 /obj/effect/shuttle_landmark/arfs/deck3/dockarm/north,
 /turf/space,
@@ -27455,17 +29117,40 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"roo" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "rqW" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"rsg" = (
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
 "rzp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard_airlock_s)
+"rzy" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "rGF" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -27477,6 +29162,40 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"rKr" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/airless/ceiling,
+/area/maintenance/engineering)
+"rNP" = (
+/obj/machinery/atmospherics/binary/pump/fuel{
+	dir = 8;
+	name = "Canisters to Tanks"
+	},
+/turf/simulated/floor/plating,
+/area/exploration/hanger)
+"rSR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/medical/medbay)
+"rST" = (
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "AutoResleeverDoor";
+	name = "Auto Resleever Door Control";
+	pixel_x = 25;
+	pixel_y = 5;
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "rUg" = (
 /obj/structure/window/reinforced,
 /obj/item/device/radio/headset{
@@ -27488,6 +29207,34 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall_starboard)
+"rUU" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
+"rVI" = (
+/obj/machinery/vending/loadout/uniform,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"rZO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/random/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "sfJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -27517,6 +29264,21 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_s)
+"snD" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"sqZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/exploration/hanger)
 "sym" = (
 /obj/structure/closet/crate{
 	dir = 1
@@ -27549,6 +29311,14 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_airlock_s)
+"sJb" = (
+/obj/fiftyspawner/glass,
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/fiftyspawner/glass,
+/turf/simulated/floor/plating,
+/area/construction)
 "sQD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -27583,12 +29353,40 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_airlock_s)
+"sTE" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "sWI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"sYs" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"sZJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "tat" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -27680,6 +29478,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/station/docking_hall_starboard)
+"tno" = (
+/obj/machinery/camera/autoname,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"txY" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "tAN" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window{
@@ -27689,6 +29502,18 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint/starboard)
+"tFQ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
 "tGn" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -27707,6 +29532,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"tIs" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "tIC" = (
 /obj/machinery/light,
 /obj/structure/bed/chair/bay{
@@ -27728,6 +29557,31 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall)
+"tPn" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"tSZ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "tTS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -27735,6 +29589,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall_starboard)
+"tTX" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "tUz" = (
 /obj/machinery/light{
 	dir = 1
@@ -27765,11 +29623,47 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard_airlock_s)
+"uby" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"ubF" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/engineering{
+	name = "Thrusters Access";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
 "ubH" = (
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"udK" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"uhG" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "uie" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -27790,6 +29684,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_n)
+"uju" = (
+/obj/machinery/door/airlock/maintenance/medical,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/medical/medbay2)
 "unD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/plating,
@@ -27805,6 +29704,60 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
+"upv" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"uuA" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Aft Hallway - Deck 2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"uwf" = (
+/obj/random/trash,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"uzq" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_engineeringatmos{
+	name = "Construction Site";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "uBe" = (
 /obj/structure/filingcabinet/security,
 /turf/simulated/floor/tiled/dark,
@@ -27823,6 +29776,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"uHC" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/construction)
+"uJb" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "uQc" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate{
@@ -27851,6 +29819,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/station/docking_hall)
+"uSA" = (
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"uXm" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "vfP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -27917,6 +29895,16 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"vyc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 5;
+	tag = "icon-corner_kafel (NORTHEAST)"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "vyJ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
@@ -27935,9 +29923,26 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"vCb" = (
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "vCT" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall)
+"vDv" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/medbay_aft)
 "vDT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -27975,6 +29980,15 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"vVs" = (
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/exploration/hanger)
 "vWN" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/station/deck_three/port_docking_arm)
@@ -27982,6 +29996,29 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"vXl" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "vZg" = (
 /obj/machinery/door/airlock/glass_external{
 	locked = 1
@@ -28008,6 +30045,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"wbL" = (
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"wcN" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "wda" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
@@ -28024,6 +30072,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_s)
+"whi" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
+"wjw" = (
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/thrusters)
 "wka" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -28034,6 +30095,12 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"wnx" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/exploration/hanger)
 "wpd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28057,6 +30124,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"wpm" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "wtT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -28072,6 +30148,28 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"wzx" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
 "wzR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28151,6 +30249,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"wUp" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay_aft)
 "wUI" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -28162,6 +30264,27 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
+"wXt" = (
+/obj/machinery/light,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/central)
+"xfj" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
 "xih" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -28187,6 +30310,18 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"xmD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "xoD" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -28210,6 +30345,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
+"xDs" = (
+/obj/machinery/camera/autoname,
+/turf/simulated/floor/plating,
+/area/construction)
 "xDy" = (
 /obj/machinery/alarm{
 	frequency = 1441;
@@ -28219,6 +30358,12 @@
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/carpet,
 /area/hallway/station/docking_hall_starboard)
+"xEm" = (
+/obj/effect/floor_decal/corner_kafel/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "xHV" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 20
@@ -28240,6 +30385,14 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/station/deck_three/port_docking_arm)
+"xJe" = (
+/obj/fiftyspawner/steel,
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/plating,
+/area/construction)
 "xLK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -28257,6 +30410,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
+"xNH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"xNL" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/engineering)
 "xOu" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -28297,6 +30468,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/station/docking_hall)
+"xYH" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "ybj" = (
 /obj/random/trash_pile,
 /obj/structure/catwalk,
@@ -28324,6 +30499,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/fore)
+"yjB" = (
+/obj/fiftyspawner/rods,
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/fiftyspawner/rods,
+/turf/simulated/floor/plating,
+/area/construction)
 "ykV" = (
 /obj/random/maintenance/clean,
 /obj/effect/floor_decal/rust,
@@ -51096,34 +53279,34 @@ asz
 aUl
 aUl
 aQu
-afV
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+prE
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
 aaa
 aaa
 aaa
@@ -51354,33 +53537,33 @@ aUl
 aUl
 aQu
 afV
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+inm
+aRn
+aqk
+gPI
+dXC
+aqa
+oua
+aZu
+aZu
+fEn
+uby
+aZu
+txY
+aqa
+sYs
+aZu
+aZu
+eus
+aZu
+aZu
+cVW
+bMk
+uSA
+njQ
+uby
+aZu
+ajm
 aaa
 aaa
 aaa
@@ -51610,34 +53793,34 @@ aUl
 aVf
 aZv
 aoP
-afV
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+jQv
+aZu
+uby
+axO
+aZu
+uSA
+aUq
+aZu
+axO
+eus
+uby
+axO
+aZu
+txY
+aqa
+pKZ
+aZu
+axO
+aZu
+sYs
+txY
+aZu
+aqa
+uby
+aZu
+uby
+njQ
+ajm
 aaa
 aaa
 aaa
@@ -51868,33 +54051,33 @@ avP
 aUl
 ajq
 afV
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+uby
+uJb
+aZu
+aZu
+uby
+aqa
+gAD
+roo
+bEB
+bEB
+uby
+lPe
+bYw
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+fEn
+uby
+ajm
 aaa
 aaa
 aaa
@@ -52125,33 +54308,33 @@ aRI
 aUl
 auh
 afV
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+aqa
+aqa
+aqa
+axO
+aqa
+sYs
+aZu
+aZu
+njQ
+kjd
+uby
+aZu
+aZu
+aZu
+aZu
+aZu
+axO
+oua
+uby
+uby
+eus
+eus
+aqa
+oua
+aZu
+ajm
 aaa
 aaa
 aaa
@@ -52382,33 +54565,33 @@ aTP
 aUe
 aUe
 aUe
-aoo
-aoo
-aoo
-aoo
-aoo
+fEn
+aqa
+aqa
+aqa
+aZu
 aoh
 aoh
 aoh
 aoh
 aoh
 aoh
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+eus
+njQ
+aZu
+fEn
+oua
+aZu
+aZu
+uby
+njQ
+uby
+aZu
+aqa
+axO
+aZu
+ajm
 aaa
 aaa
 aaa
@@ -52639,11 +54822,11 @@ akm
 aov
 aoW
 aUe
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+aZu
+ici
+aZu
+aZu
 aoh
 aVm
 aMy
@@ -52651,21 +54834,21 @@ aAj
 aVL
 aoh
 aoh
-aSX
-aSX
-aSX
-aSX
-aSX
-aSX
 aoh
 aoh
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aoh
+aoh
+aoh
+aoh
+aoh
+aqa
+aZu
+uby
+uby
+aZu
+aZu
+fEn
+ajm
 aaa
 aaa
 aaa
@@ -52896,11 +55079,11 @@ akm
 aAn
 aKF
 aUe
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+aZu
+aZu
+uby
+fEn
 aoh
 aGH
 aTq
@@ -52915,14 +55098,14 @@ aLc
 asM
 aUB
 aRm
-aoh
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aqa
+eUV
+eUV
+aZu
+kjd
+eus
+aZu
+ajm
 aaa
 aaa
 aaa
@@ -53153,10 +55336,10 @@ akm
 aAn
 aWD
 aUe
-aoo
-aoo
-aoo
-aoo
+aqa
+aqa
+aqa
+aUq
 aoh
 aoh
 aoh
@@ -53178,16 +55361,16 @@ aou
 aou
 aou
 aou
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aUq
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
+ajm
 aaa
 aaa
 aaa
@@ -53410,10 +55593,10 @@ amy
 aAn
 amF
 aUe
-aoo
-aoo
-aoo
-aoo
+gig
+eus
+uby
+axO
 aoh
 anP
 aIL
@@ -53435,16 +55618,16 @@ aFK
 aJQ
 akl
 aou
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+uby
+uSA
+sYs
+aqa
+aZu
+aZu
+aZu
+eUV
+aZu
+ajm
 aoo
 aoo
 aoo
@@ -53667,10 +55850,10 @@ amz
 aJa
 amG
 aUe
-aoo
-aoo
-aoo
-aoo
+gPI
+uby
+aZu
+aZu
 aoh
 aoh
 aoh
@@ -53692,16 +55875,16 @@ asy
 ano
 aGB
 aou
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+njQ
+uby
+aqa
+eUV
+uby
+aZu
+uby
+aZu
+ajm
 aoo
 aoo
 aoo
@@ -53924,10 +56107,10 @@ amA
 amD
 amH
 aUe
-aoo
-aoo
-aoo
-aoo
+aZu
+fEn
+aqa
+eus
 aoh
 anP
 aIL
@@ -53949,16 +56132,16 @@ aok
 aQe
 aPR
 aou
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+fEn
+uby
+lPe
+aqa
+aZu
+uby
+kdO
+uby
+uby
+ajm
 aoo
 aoo
 aoo
@@ -54181,10 +56364,10 @@ atc
 aAn
 amI
 aUe
-aoo
-aoo
-aoo
-aoo
+aZu
+ici
+aqa
+fEn
 aoh
 aoh
 aoh
@@ -54206,16 +56389,16 @@ aGW
 ayZ
 aPT
 aou
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+axO
+uby
+ivk
+aqa
+aZu
+aZu
+uby
+aZu
+sYs
+ajm
 aoo
 aoo
 aoo
@@ -54438,10 +56621,10 @@ aAn
 aAn
 amJ
 aUe
-aoo
-aoo
-aoo
-aoo
+aZu
+aZu
+aqa
+sYs
 aoh
 aZH
 aIL
@@ -54463,16 +56646,16 @@ aGi
 aPJ
 aBS
 aou
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+aZu
+aZu
+aqa
+sYs
+aZu
+aZu
+aZu
+mgQ
+ajm
 aoo
 aoo
 aoo
@@ -54696,7 +56879,7 @@ aYJ
 amK
 aUe
 aqa
-aqa
+aUq
 aqa
 aqa
 aoh
@@ -54720,38 +56903,38 @@ aDr
 aou
 aou
 aou
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aqa
+aUq
+aqa
+aqa
+aqa
+aqa
+aUq
+aqa
+aqa
+ajm
+ajm
+ajm
+ajm
+ajm
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
+qsL
 aaa
 aaa
 aaa
@@ -54952,7 +57135,7 @@ aUe
 aUe
 aUe
 aUe
-aZu
+uSA
 aZu
 aqk
 aRn
@@ -54977,38 +57160,38 @@ aNi
 aGn
 aPG
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+mgQ
+axO
+lPe
+aZu
+aZu
+axO
+lPe
+aZu
+aZu
+aZu
+aZu
+aZu
+sYs
+aqa
+fFt
+aAH
+fFt
+fFt
+xYH
+ath
+pmr
+rUU
+fFt
+aAH
+fFt
+ath
+pvJ
+tIs
+iLs
+mqc
+pmr
+qsL
 aaa
 aaa
 aaa
@@ -55194,20 +57377,20 @@ aRf
 aHH
 alv
 ajU
-ahK
-ahK
-ahK
+tFQ
+tFQ
+fQP
 ahL
 ahK
 ahM
-ahK
-ahK
+tFQ
+xfj
 ahN
-ahH
-aOi
-aOi
+aLH
+aZu
 aUq
-aUq
+aZu
+aZu
 aqa
 azy
 aVD
@@ -55233,42 +57416,42 @@ aEk
 aOY
 aEk
 aYC
-atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+uju
+aZu
+aZu
+uSA
+aZu
+ivk
+aZu
+uby
+aZu
+njQ
+uby
+ivk
+axO
+uby
+aqa
+euS
+xNL
+lVx
+ajC
+fFt
+ath
+euS
+euS
+euS
+euS
+fFt
+ath
+fFt
+aDJ
+ajC
+euS
+fFt
+qsL
+qsL
+qsL
+qsL
 aoo
 aoo
 aoo
@@ -55463,13 +57646,13 @@ ahH
 ahH
 ahW
 ahW
-aUq
-aUq
+aZu
+fEn
 aqa
-apm
-aZu
-aZu
-aZu
+bDh
+uby
+fEn
+cwX
 atH
 apx
 aEk
@@ -55491,41 +57674,41 @@ aTA
 aEk
 aWf
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+sYs
+njQ
+ouH
+hHb
+nve
+nve
+nve
+tTX
+ceP
+fUl
+ceP
+uby
+uby
+pFJ
+euS
+fFt
+ath
+euS
+ajC
+ajC
+ajC
+fFt
+ath
+ajC
+euS
+mTh
+euS
+frr
+frr
+frr
+euS
+ajC
+aAH
+jmh
+qsL
 aoo
 aoo
 aoo
@@ -55720,13 +57903,13 @@ aig
 ajy
 ajE
 ahW
-aUq
-aUq
+sYs
+uby
 aqa
 apm
-aZu
-aZu
-aZu
+ici
+aAb
+aAb
 aAb
 aNq
 aEk
@@ -55748,41 +57931,41 @@ aEl
 aTk
 auF
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+uby
+mzZ
+aqa
+aqa
+dqf
+dqf
+kYg
+aqa
+aqa
+bhI
+uby
+fEn
+aqa
+cFE
+pmr
+ath
+rUU
+aAH
+aAH
+pvJ
+pvJ
+ath
+fFt
+fFt
+fFt
+lOX
+pFn
+pFn
+pFn
+nWL
+euS
+aAH
+fFt
+qsL
 aoo
 aoo
 aoo
@@ -55977,15 +58160,15 @@ aiH
 ajz
 ajG
 ahW
-aUq
-aUq
+cGW
+uby
 aqa
-apm
-aZu
-aZu
+rZO
 aZu
 aAb
-aJl
+olY
+xEm
+aVP
 aEk
 aEk
 aEk
@@ -56005,42 +58188,42 @@ atH
 atH
 atH
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+axO
+wbL
+nve
+aqa
+hYh
+hYh
+hYh
+hYh
+hYh
+bOm
+nve
+uby
+aZu
+aqa
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+kqO
+ajF
+ajF
+aVi
+aVi
 aVi
 aVi
 aVi
@@ -56234,15 +58417,15 @@ aju
 ahZ
 ajH
 ahW
-aUq
-aUq
+uby
+uby
 aqa
 aCQ
-ath
-ath
 aOh
 aAb
-axO
+aUo
+mpv
+aTk
 ayR
 ayR
 ayR
@@ -56258,50 +58441,50 @@ aZo
 aPb
 aOU
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+gkm
+aZu
+aqa
+aZu
+uby
+nve
+dqf
+hYh
+sYs
+oGT
+sYs
+hYh
+dqf
+ceP
+axO
+uby
+aZu
+bSh
+djz
+djz
+djz
+dpy
+phi
+djz
+djz
+djz
+djz
+djz
+phi
+dpy
+jGp
+djz
+djz
+bSh
+wpm
+gfR
+kPp
 aVi
+cbG
+hQv
 akx
 apo
-arN
+kHG
 aCL
 aDI
 awu
@@ -56491,14 +58674,14 @@ ahW
 ahW
 ahW
 ahW
-aUq
-aUq
-aqa
-apm
+uby
 aZu
+aUq
+bDh
 aZu
 aAb
-aAb
+vyc
+gGb
 aAb
 aGL
 aGL
@@ -56515,52 +58698,52 @@ aJl
 aEk
 aCo
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aVi
+axO
+uby
+eus
+aqa
+uby
+ivk
+ceP
+kYg
+hYh
+hbC
+aqa
+mKr
+hYh
+dqf
+ceP
+uby
+aZu
+aZu
+bSh
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+qJt
+jGD
+ort
+xNH
+mfJ
+ubF
+pGC
+pGC
 akE
 aqf
 auU
-arN
-aDJ
+asG
+aDT
 awL
 aKO
 aKO
@@ -56748,14 +58931,14 @@ ajv
 aig
 ajI
 ahW
-aUq
-aUq
+aZu
+eus
 aqa
 apm
-aZu
-aZu
+uby
 aAb
-aRt
+aUo
+gGb
 aFW
 aRt
 aRt
@@ -56772,49 +58955,49 @@ aUP
 aEk
 aXt
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+uby
+uby
+uby
+aqa
+aZu
+aZu
+tTX
+dqf
+hYh
+sYs
+oGT
+sYs
+hYh
+dqf
+ceP
+fEn
+aZu
+uby
+bSh
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+paK
+bSh
+tno
+jzQ
+uXm
 aVi
+wjw
+dkj
 alT
-arN
+asG
 awi
 aCW
 aDM
@@ -57005,14 +59188,14 @@ aiA
 ajA
 ajN
 ahW
-aUq
-aUq
+fEn
+aZu
 aqa
-apm
-aZu
-aZu
+lBb
+gPI
 aAb
-aRt
+aUo
+gGb
 aFW
 aRt
 aRt
@@ -57029,47 +59212,47 @@ aJl
 aEk
 aCo
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+uSA
+uby
+aZu
+aUq
+uby
+uby
+ceP
+jZq
+hYh
+hYh
+hYh
+hYh
+hYh
+aqa
+ceP
+uby
+uby
+hyx
+bSh
+xDs
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+cWd
+cvJ
+bSh
+jJG
+rlZ
+mpd
 aVi
+eKj
+rsg
 aEA
 atm
 aws
@@ -57262,14 +59445,14 @@ aio
 aig
 ajN
 ahW
-aUq
-aUq
+aZu
+gPI
 aqa
 apm
 aZu
-aZu
 aAb
-aRt
+aUo
+gGb
 aFW
 aRt
 aRt
@@ -57286,47 +59469,47 @@ aJl
 aEk
 aCo
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+ivk
+eus
+axO
+aqa
+oua
+uby
+vDv
+aqa
+aqa
+kYg
+kYg
+dqf
+aqa
+aqa
+bhI
+aZu
+uby
+uwf
+bSh
+oIx
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+uHC
+bSh
+fot
+jzQ
+ogf
 aVi
+gzO
+cRo
 aEA
 atm
 ayS
@@ -57519,14 +59702,14 @@ aio
 aig
 ajO
 ahW
-aUq
-aUq
 aqa
-apm
-aZu
-aZu
+aqa
+aqa
+iAc
+aqa
 aAb
-aRt
+aUo
+gGb
 aFW
 aRt
 aRt
@@ -57543,46 +59726,46 @@ aNq
 aEk
 aPe
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+uby
+aZu
+aqa
+axO
+aZu
+ceP
+jWE
+eNs
+nve
+ceP
+ceP
+ceP
+jWE
+tTX
+aZu
+uby
+axO
+bSh
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+bSh
+lvN
+hTO
+kuk
+aVi
+aVi
 aVi
 aVi
 atm
@@ -57776,14 +59959,14 @@ aio
 aig
 ajP
 ahW
+aZu
 aUq
-aUq
-aqa
+aZu
 apm
-aZu
-aZu
+eus
 aAb
-aRt
+fQO
+gGb
 aFW
 aRt
 aRt
@@ -57801,51 +59984,51 @@ aEk
 aCo
 atH
 atH
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+whi
+qVk
+aqa
+aZu
+qoE
+aZu
+aZu
+aZu
+aZu
+oua
+sYs
+aZu
+uby
+aZu
+aZu
+aZu
+aZu
+bSh
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+bSh
+fot
+jzQ
+uXm
+ath
+knz
+plb
 aVi
 atm
-aAH
+azg
 aDu
-aEa
+asG
 awL
 aKO
 aKO
@@ -58033,14 +60216,14 @@ aiB
 ajB
 ajQ
 ahW
-aUq
-aUq
+uby
 aqa
-apm
 aZu
-aZu
+mde
+axO
 aAb
-aRt
+vyc
+gGb
 aFW
 aRt
 aRt
@@ -58065,39 +60248,39 @@ aWQ
 aWQ
 aWQ
 aWQ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+iAA
+plU
+wUp
+aqa
+bSh
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+bSh
+fot
+jzQ
+uXm
+pkb
+dTp
+plb
 aVi
 aVi
 aAM
@@ -58290,14 +60473,14 @@ ajw
 aig
 ajR
 ahW
-aUq
-aUq
+ivk
 aqa
-apm
 aZu
-aZu
+dax
+gPI
 aAb
-aRt
+lSR
+lJu
 aaw
 ajX
 ajX
@@ -58322,39 +60505,39 @@ anF
 aGp
 aol
 aWQ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+sYs
+pRm
+uby
+aZu
+axO
+uby
+fEn
+fEn
+uby
+axO
+bSh
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+bSh
+fot
+jzQ
+iQh
+ath
+doV
+knz
 aVi
 atm
 aBM
@@ -58547,13 +60730,13 @@ ahW
 ahW
 ahW
 ahW
-aUq
-aUq
+uby
 aqa
-apm
-aZu
-aZu
+eus
+dax
 aAb
+aAb
+hWP
 aAb
 aAb
 aRt
@@ -58579,44 +60762,44 @@ aLx
 aYx
 aVH
 aWQ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+aZu
+aZu
+oua
+aZu
+aZu
+axO
+uby
+aZu
+fEn
+bSh
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+bSh
+fot
+jzQ
+ogf
+ath
+ath
+dTp
 aVi
 atm
 aBM
-arN
-aDJ
+asG
+aDT
 awL
 aKO
 aKO
@@ -58804,14 +60987,14 @@ aig
 ajy
 ajS
 ahW
-aUq
-aUq
+eus
 aqa
-apm
-aZu
-aZu
-aZu
-aZu
+axO
+dax
+aAb
+odu
+lMN
+naQ
 aAb
 aRt
 aRt
@@ -58836,39 +61019,39 @@ asW
 ayG
 asK
 aWQ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aqa
+aUq
+aqa
+aqa
+aqa
+aqa
+aqa
+aUq
+aqa
+aqa
+bSh
+oIx
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+msf
+bSh
+fot
+jzQ
+odW
+ath
+nhQ
+iQz
 aVi
 atm
 aBP
@@ -59061,14 +61244,14 @@ aiH
 ajz
 ajG
 ahW
-aUq
-aUq
+aZu
 aqa
+aqk
 apm
-aZu
-aZu
-aZu
-aZu
+aAb
+qBu
+oCh
+dgI
 aAb
 aRt
 aRt
@@ -59093,39 +61276,39 @@ aKG
 aFh
 anL
 aWQ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+fEn
+uby
+sYs
+aqa
+aZu
+uby
+oua
+aZu
+axO
+sYs
+bSh
+xDs
+djz
+djz
+nzN
+nwg
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+cvJ
+bSh
+tno
+jzQ
+uXm
+ath
+rKr
+plb
 aVi
 atm
 aBZ
@@ -59318,14 +61501,14 @@ aju
 ahZ
 ajH
 ahW
-aUq
-aUq
+uby
 aqa
-apm
-aZu
-aZu
-aZu
-aZu
+aRn
+dax
+aAb
+upv
+hno
+rVI
 aAb
 aRt
 aRt
@@ -59350,39 +61533,39 @@ aKG
 aom
 aSF
 aWQ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+mxL
+axO
+inm
+aqa
+sYs
+aZu
+axO
+aZu
+uby
+aZu
+bSh
+djz
+djz
+djz
+eJV
+yjB
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+bSh
+qbw
+rlZ
+emY
+ath
+obj
+dTp
 aVi
 atm
 aCp
@@ -59560,8 +61743,8 @@ duE
 bDp
 duE
 afV
-aFf
-ajq
+wzx
+wXt
 ahW
 ahW
 ahW
@@ -59575,14 +61758,14 @@ ahW
 ahW
 ahW
 ahW
-aUq
-aUq
+fEn
 aqa
+inm
 apm
-aZu
-aZu
-aZu
-aZu
+aAb
+qzg
+tSZ
+rST
 aAb
 aRt
 aRt
@@ -59607,39 +61790,39 @@ aFr
 aYx
 aVH
 aWQ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+njQ
+fEn
+aRn
+aqa
+loy
+aZu
+uby
+uJb
+aZu
+axO
+bSh
+djz
+djz
+djz
+sJb
+xJe
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+djz
+bSh
+vCb
+jzQ
+uXm
+ath
+ath
+knz
 aVi
 atm
 aCr
@@ -59817,32 +62000,32 @@ oaW
 duE
 bDp
 afV
-ajm
-ajC
-afV
-aOi
-aOi
-aOi
-aOi
-aOi
-aOi
-aOi
-aOi
-aOi
-aOi
-aOi
-aOi
-aUq
-aUq
+aFf
+aUl
+jQv
+uby
+fEn
+aZu
+axO
+uby
+uSA
+aZu
+fEn
+aZu
+uby
+axO
+aZu
+aZu
 aqa
+kjd
 apm
-aZu
-aZu
-aZu
-aZu
+aAb
+rSR
+ebj
+aAb
 aAb
 aRt
-aRt
+aEp
 aRt
 aRt
 aUG
@@ -59864,44 +62047,44 @@ aLm
 aLm
 aQF
 aWQ
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aZu
+oua
+aqk
+aqa
+loy
+oua
+aZu
+aqa
+aUq
+aqa
+bSh
+djz
+djz
+blM
+wcN
+djz
+jDu
+ldD
+hwU
+bcc
+mHB
+blM
+wcN
+djz
+djz
+djz
+bSh
+fot
+jzQ
+uXm
+ath
+knz
+plb
 aVi
 atm
 aCy
 aDu
-aEa
+asG
 awL
 aKO
 aKO
@@ -60093,11 +62276,11 @@ ajF
 ajF
 ajF
 aBO
-ajF
-ajF
-ajF
-ajF
-ajF
+aAb
+mpM
+joA
+hGQ
+aAb
 ajF
 ajF
 ajF
@@ -60121,39 +62304,39 @@ aNw
 aWW
 aZy
 aWQ
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-axA
-aoo
-aoo
+aUq
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+wpm
+fef
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+uzq
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+bSh
+fot
+jzQ
+uXm
+pkb
+plb
+plb
 aVi
 asG
 aCA
@@ -60333,90 +62516,90 @@ avJ
 aUl
 aFf
 aUl
-aUl
+oJO
 aIj
 apw
 aLy
-aMa
-ltj
-aMa
-aMa
-aMa
-axH
-aLy
-aMa
-aMa
-aMa
-aMa
-aMa
-aBN
-aZb
-aZC
-aMa
-aXQ
-aTv
 apC
-aMa
-aMa
-mAz
-aMa
-aMa
-ajh
-aMa
-aMa
-aMa
-aMa
-aMa
-aMa
-aLC
-aMa
-aXQ
-aTv
-aZC
-aMa
-aMa
-aZb
-aMa
-aMa
-aMa
-aLy
+ltj
+apC
+apC
+apC
 axH
-aMa
-aMa
-aMa
-aMa
-aMa
-aMa
 aLy
+apC
+apC
+apC
+apC
+apC
+aBN
+ehV
 aZC
-aMa
-aMa
-aMa
-aMa
-aMa
-aMa
-aLy
-aMa
-aZC
-aMa
-aMa
-aMa
-aMa
-aMa
-aMa
-aMa
-aZC
-aLy
-aMa
-axA
-aoo
-aoo
+qzD
+esT
+dfo
+apC
+apC
+apC
+mAz
+apC
+apC
+ajh
+apC
+apC
+apC
+apC
+apC
+apC
+aLC
+apC
+aXQ
+udK
+fBL
+apC
+apC
+aZb
+apC
+apC
+ioJ
+mRx
+ppc
+gfR
+gfR
+gfR
+gfR
+sTE
+olx
+lQw
+meR
+rzy
+fbG
+gfR
+aEa
+ppc
+gfR
+mRx
+ivP
+meR
+gfR
+gfR
+gfR
+aEa
+ppc
+rzy
+gfR
+gTR
+jzQ
+iQh
+ath
+cbP
+doV
 aVi
 asG
-arN
-arN
-aEp
 asG
+arN
+aEr
+fBd
 asG
 aVi
 aaa
@@ -60609,7 +62792,7 @@ aKB
 akX
 awT
 atM
-awT
+iwQ
 atM
 asE
 awT
@@ -60640,11 +62823,20 @@ awT
 awT
 awT
 aKt
+aKB
+aKB
+aKB
+aKB
+aKB
+aTQ
+aYN
+lOs
 aYN
 aYN
 aYN
 aYN
 aYN
+vXl
 aBx
 aBH
 aBH
@@ -60653,23 +62845,14 @@ aBH
 aBH
 aBH
 aBH
-aBH
 aBx
-aBH
-aBH
-aBH
-aBH
-aBH
-aBH
-aBH
-aUo
-aMa
-aMa
+enG
+uXm
 axA
 aFv
 aFv
 aFv
-aFv
+fwB
 aFv
 aFv
 aEr
@@ -60847,86 +63030,86 @@ avJ
 aUl
 ajj
 aUl
-aUl
-aIj
+eAM
+uuA
 aYz
 aUD
-aMa
-aMa
-aMa
-aMa
-aMa
+ijk
+ijk
+ijk
+ijk
+ijk
 aEx
-aMa
-awe
-aMa
-aMa
-aMa
-aMa
-aMa
-aMa
+ijk
+uhG
+ijk
+ijk
+ijk
+sZJ
+ijk
+ijk
 aYz
-aMa
+ijk
 aYz
-aTv
-aMa
+tPn
+gVo
 aMa
 aYo
 aMa
-aMa
-aMa
+jio
+ivY
 aEx
-aMa
-aMa
+ijk
+ijk
 anS
-aMa
-aMa
-aMa
-aMa
-aMa
+ijk
+ijk
+ijk
+ijk
+ijk
 aYz
-aTv
+tPn
 aYz
-awe
-aMa
-aMa
-aMa
-aMa
-aMa
-aMa
+uhG
+ijk
+ijk
+ijk
+ijk
+ijk
+ijk
 aEx
-aMa
+ijk
 aQX
-aMa
-awe
-aMa
-aMa
-aMa
-aYz
-aMa
-aMa
-akI
-aMa
-aMa
-aMa
-aMa
-aMa
-aYz
-aMa
-aMa
-aMa
-akI
-aMa
-aMa
-aMa
-aYz
-aMa
-aMa
+ijk
+uhG
+ijk
+dKX
+dKX
+kvk
+dKX
+omH
+xmD
+dKX
+dKX
+dKX
+dKX
+qSk
+kvk
+pBI
+dKX
+boS
+xmD
+dKX
+dKX
+dKX
+kvk
+pBI
+snD
 axA
 ayA
+vVs
+ffX
 aNr
-aKe
-aKe
 bax
 aFv
 aEt
@@ -61126,10 +63309,10 @@ aZr
 aZr
 aFV
 aNX
-akI
-aMa
-aYo
-aMa
+ftC
+ijk
+fwq
+ijk
 akI
 ajF
 ajF
@@ -61157,33 +63340,33 @@ aHw
 aTv
 axA
 axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
+qzE
+qzE
+qzE
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
+ajF
 axA
 aGj
 aNJ
 aEn
-aKe
+rNP
 aKe
 aFv
 alc
@@ -61414,34 +63597,34 @@ alP
 aQw
 aNB
 asX
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+oHr
+rlg
+dBB
+aRs
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
 aFv
 aGj
 unD
 bas
-aKe
-aKe
+wnx
+bmh
 aFv
 aVi
 aVi
@@ -61671,34 +63854,34 @@ aWy
 ato
 aUO
 asX
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aRs
+aRs
+aRs
+aRs
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
 aFv
 aGj
 unD
 aEG
-aKe
-aKe
+sqZ
+bmh
 aFv
 aaa
 aaa
@@ -61928,28 +64111,28 @@ anV
 awK
 aJb
 asX
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
-aoo
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
+aIm
 aFv
 aGj
 aSw
@@ -62466,7 +64649,7 @@ aVz
 aVz
 baD
 aon
-aVz
+dKm
 bav
 aVz
 aVz
@@ -75709,10 +77892,10 @@ xHV
 eGa
 oqc
 dbS
-rgd
-tUT
 mdY
-wUI
+tUT
+eRl
+jDb
 aaa
 aaa
 aaa
@@ -75966,7 +78149,7 @@ hqF
 iwY
 bDz
 tAN
-bhR
+eoz
 ivM
 tHY
 wUI
@@ -76480,9 +78663,9 @@ qkB
 mkX
 qGg
 vMZ
-mdY
-tUT
-mdY
+fZO
+eeo
+qfU
 jDb
 aaa
 aaa

--- a/maps/Arfs/arfs_areas.dm
+++ b/maps/Arfs/arfs_areas.dm
@@ -36,7 +36,7 @@
 /area/shuttle/drake/quarters2
 	name = "\improper Drake Quarters 2"
 	icon_state = "gray-s"
-/area/shuttle/drake/galley	
+/area/shuttle/drake/galley
 	name = "\improper Drake Galley"
 	icon_state = "dark-p"
 /area/shuttle/drake/storage
@@ -356,3 +356,11 @@
 
 //checkpoints
 /area/security/checkpoint/starboard
+	name = "\improper Security Checkpoint - Starboard Docking Arm"
+
+/area/security/checkpoint/port
+	name = "\improper Security Checkpoint - Port Docking Arm"
+
+//Medbay
+/area/medical/medbay/autoresleever
+	name = "\improper Auto-resleeving Lab"


### PR DESCRIPTION
1. adds autoresleever room
2. massively expands maintenance on deck 3 in the aft of the ship
3. connects the thruster room to the hallway on deck 3
4. adds a large construction site to deck 3 near the thrusters
5. fixes the grass on the pokemon teleporter on deck 2
6. fixes the warden's consoles
7. makes the warden's window shutter a different button
8. Moves the armory shutter button into the armory
9. adds floor decals to deck 3 hallways
10. makes showers actually wash your feet of oil/blood
11. added direction signs to the deck 3 hallways