### PR TITLE
Adds Riding Functionality to Pokemon and More

### DIFF
--- a/code/__defines/arfs_defines.dm
+++ b/code/__defines/arfs_defines.dm
@@ -27,4 +27,7 @@
 #define	M_TF			"transformed" //A ditto or something has transformed
 #define M_INVIS			"invisible" //Mew can turn invisible, but not ethereal like M_GHOSTED
 
+#define P_TRAIT_BLACKLIST	"blacklist" //Don't spawn this pokemon or show it in lists.
+#define P_TRAIT_RIDEABLE	"rideable"  //This pokemon can be buckled to, ridden, and steered like a vehicle
+
 #define MAP_LEVEL_VORESPAWN	0x100 // Z-levels players are allowed to late join to via vorish means. Usually non-dangerous locations.

--- a/content_arfs/code/mob/pokemon.dm
+++ b/content_arfs/code/mob/pokemon.dm
@@ -312,6 +312,7 @@
 	icon_dead = "lugia_d"
 	p_types = list(P_TYPE_PSYCH, P_TYPE_FLY)
 	movement_cooldown = 1.5
+	mob_size = MOB_HUGE
 
 /mob/living/simple_mob/animal/passive/pokemon/leg/lugia/andy
 	health = 500
@@ -329,6 +330,7 @@
 	icon_dead = "rayquaza_d"
 	p_types = list(P_TYPE_FLY)
 	movement_cooldown = 1.5
+	mob_size = MOB_HUGE
 
 
 ///////////////////////////////
@@ -351,6 +353,8 @@
 	icon_dead = "aggron_d"
 	p_types = list(P_TYPE_STEEL)
 	movement_cooldown = 5
+	mob_size = MOB_LARGE
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/alolanvulpix
 	name = "alolan vulpix"
@@ -361,6 +365,7 @@
 	p_types = list(P_TYPE_ICE)
 	additional_moves = list(/mob/living/proc/hide)
 	mob_size = MOB_SMALL
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/ampharos
 	name = "ampharos"
@@ -368,6 +373,7 @@
 	icon_living = "ampharos"
 	icon_dead = "ampharos_d"
 	p_types = list(P_TYPE_ELEC)
+	mob_size = MOB_LARGE
 
 /mob/living/simple_mob/animal/passive/pokemon/braixen
 	name = "braixen"
@@ -392,6 +398,7 @@
 	icon_dead = "charmander_d"
 	p_types = list(P_TYPE_FIRE)
 	mob_size = MOB_SMALL
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/ditto
 	name = "ditto"
@@ -413,6 +420,7 @@
 	additional_moves = list(/mob/living/simple_mob/animal/passive/pokemon/proc/move_fly,
 							/mob/living/simple_mob/animal/passive/pokemon/proc/move_hover)
 	p_traits = list(P_TRAIT_RIDEABLE)
+	mob_size = MOB_LARGE
 
 /mob/living/simple_mob/animal/passive/pokemon/dragonite
 	name = "dragonite"
@@ -423,6 +431,7 @@
 	p_types = list(P_TYPE_DRAGON, P_TYPE_FLY)
 	aquatic_movement = 1
 	p_traits = list(P_TRAIT_RIDEABLE)
+	mob_size = MOB_LARGE
 
 /mob/living/simple_mob/animal/passive/pokemon/dratini
 	name = "dratini"
@@ -434,6 +443,7 @@
 	aquatic_movement = 1
 	p_types = list(P_TYPE_DRAGON)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/eevee
 	name = "eevee"
@@ -444,6 +454,7 @@
 	p_types = list(P_TYPE_NORM)
 	additional_moves = list(/mob/living/proc/hide)
 	mob_size = MOB_SMALL
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/espeon
 	name = "espeon"
@@ -463,6 +474,7 @@
 	p_types = list(P_TYPE_FIRE)
 	additional_moves = list(/mob/living/proc/hide)
 	mob_size = MOB_SMALL
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/flaaffy
 	name = "flaaffy"
@@ -652,6 +664,7 @@
 	additional_moves = list(/mob/living/proc/hide)
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SMALL
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/mightyena
 	name = "mightyena"
@@ -700,6 +713,7 @@
 	p_types = list(P_TYPE_DARK)
 	additional_moves = list(/mob/living/proc/hide)
 	mob_size = MOB_SMALL
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/sylveon
 	name = "sylveon"
@@ -730,6 +744,7 @@
 	p_types = list(P_TYPE_FIRE)
 	additional_moves = list(/mob/living/proc/hide)
 	mob_size = MOB_SMALL
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/tentacruel
 	name = "tentacruel"
@@ -764,6 +779,8 @@
 	icon_living = "ponyta"
 	icon_dead = "ponyta_d"
 	p_types = list(P_TYPE_FIRE)
+	p_traits = list(P_TRAIT_RIDEABLE)
+	mob_size = MOB_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/zubat

--- a/content_arfs/code/mob/pokemon.dm
+++ b/content_arfs/code/mob/pokemon.dm
@@ -34,6 +34,7 @@
 	var/move_cooldown = FALSE
 	var/list/p_types = list()
 	var/list/additional_moves = list()
+	var/list/p_traits = list() //List of passive traits/flags.
 	var/resting_heal_max = 2
 	var/on_manifest = FALSE
 	var/list/active_moves = list() 	//Moves that are passive or toggles can be found here
@@ -59,6 +60,9 @@
 	if(p_types.len)//Give type specific verbs and such
 		for(var/T in p_types)
 			give_moves(T)
+	if(p_traits.len)
+		for(var/TR in p_traits)
+			give_trait(TR)
 
 /mob/living/simple_mob/animal/passive/pokemon/Life()
 	..()
@@ -251,6 +255,28 @@
 				attack_target(A)
 	return 1
 
+//Might moves this to pokemon_moves.dm
+/mob/living/simple_mob/animal/passive/pokemon/proc/give_trait(var/trait)
+	if(!trait)
+		return FALSE
+	switch(trait)
+		if(P_TRAIT_RIDEABLE)
+			max_buckled_mobs = 1
+			can_buckle = TRUE
+			buckle_movable = TRUE
+			buckle_lying = FALSE
+			riding_datum = new /datum/riding/pokemon(src)
+			verbs |= /mob/living/proc/toggle_rider_reins //Let riders take control
+			verbs |= /mob/living/simple_mob/animal/passive/pokemon/proc/riding_mount //Make people ride you
+	return TRUE
+
+/mob/living/simple_mob/animal/passive/pokemon/CtrlClickOn(var/atom/A)
+	if(M_GHOSTED in active_moves)
+		to_chat(src,"<span class='warning'>You need to rematerialize to do that!</span>")
+		return FALSE
+	else
+		. = ..()
+
 /////TEMPLATE/////
 /*
 /mob/living/simple_mob/animal/passive/pokemon
@@ -316,6 +342,7 @@
 	icon_dead = "absol_d"
 	p_types = list(P_TYPE_DARK)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/aggron
 	name = "aggron"
@@ -333,6 +360,7 @@
 	tt_desc = "Alolan Vulpix"
 	p_types = list(P_TYPE_ICE)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/ampharos
 	name = "ampharos"
@@ -355,6 +383,7 @@
 	icon_living = "celebi"
 	icon_dead = "celebi_d"
 	p_types = list(P_TYPE_PSYCH, P_TYPE_GRASS)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/charmander
 	name = "charmander"
@@ -362,6 +391,7 @@
 	icon_living = "charmander"
 	icon_dead = "charmander_d"
 	p_types = list(P_TYPE_FIRE)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/ditto
 	name = "ditto"
@@ -370,7 +400,7 @@
 	icon_dead = "ditto_d"
 	p_types = list(P_TYPE_NORM)
 	additional_moves = list(/mob/living/proc/hide, /mob/living/simple_mob/animal/passive/pokemon/proc/move_imposter)//amogus
-	 //Can probably form a hand from its body, plus a lot of its tfs have them
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/dragonair
 	name = "dragonair"
@@ -382,7 +412,7 @@
 	aquatic_movement = 1
 	additional_moves = list(/mob/living/simple_mob/animal/passive/pokemon/proc/move_fly,
 							/mob/living/simple_mob/animal/passive/pokemon/proc/move_hover)
-
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/dragonite
 	name = "dragonite"
@@ -392,6 +422,7 @@
 	icon_dead = "dragonite_d"
 	p_types = list(P_TYPE_DRAGON, P_TYPE_FLY)
 	aquatic_movement = 1
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/dratini
 	name = "dratini"
@@ -412,6 +443,7 @@
 	icon_dead = "eevee_d"
 	p_types = list(P_TYPE_NORM)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/espeon
 	name = "espeon"
@@ -421,6 +453,7 @@
 	icon_dead = "espeon_d"
 	p_types = list(P_TYPE_PSYCH)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/fennekin
 	name = "fennekin"
@@ -429,6 +462,7 @@
 	icon_dead = "fennekin_d"
 	p_types = list(P_TYPE_FIRE)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/flaaffy
 	name = "flaaffy"
@@ -437,6 +471,7 @@
 	icon_dead = "flaaffy_d"
 	p_types = list(P_TYPE_ELEC)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/flareon
 	name = "flareon"
@@ -446,6 +481,7 @@
 	icon_dead = "flareon_d"
 	p_types = list(P_TYPE_FIRE)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/furret
 	name = "furret"
@@ -454,6 +490,7 @@
 	icon_dead = "furret_d"
 	p_types = list(P_TYPE_NORM)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/gallade
 	name = "gallade"
@@ -498,6 +535,7 @@
 	icon_dead = "glaceon_d"
 	p_types = list(P_TYPE_ICE)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/haunter
 	name = "haunter"
@@ -516,9 +554,18 @@
 	icon_dead = "jolteon_d"
 	p_types = list(P_TYPE_ELEC)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_mob/animal/passive/pokemon/attack_hand(mob/user)
-	..()
+/mob/living/simple_mob/animal/passive/pokemon/attack_hand(mob/user as mob)
+	if(LAZYLEN(buckled_mobs)) //Handle unbuckling riding mobs
+		if(user in buckled_mobs)
+			riding_datum.force_dismount(user)
+		if(user == src)
+			for(var/rider in buckled_mobs)
+				riding_datum.force_dismount(rider)
+	else
+		. = ..()
+	//Shock them after they attack or whatever, so they actually affect the pkmn in question
 	if(!stat && (M_SHOCK in active_moves))
 		electrocute_mob(user, get_area(src), src, 1)
 
@@ -555,6 +602,7 @@
 	icon_dead = "kirlia_d"
 	p_types = list(P_TYPE_PSYCH, P_TYPE_FAIRY)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/larvitar
 	name = "larvitar"
@@ -565,6 +613,7 @@
 	icon_dead = "larvitar_d"
 	p_types = list(P_TYPE_ROCK, P_TYPE_GROUND)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/leafeon
 	name = "leafeon"
@@ -572,6 +621,7 @@
 	icon_living = "leafeon"
 	icon_dead = "leafeon_d"
 	p_types = list(P_TYPE_GRASS)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/linoone
 	name = "linoone"
@@ -580,6 +630,8 @@
 	icon_dead = "linoone_d"
 	p_types = list(P_TYPE_NORM)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/growlithe
 	name = "growlithe"
@@ -588,6 +640,8 @@
 	icon_dead = "growlithe_d"
 	p_types = list(P_TYPE_FIRE)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/mareep
 	name = "mareep"
@@ -596,6 +650,8 @@
 	icon_dead = "mareep_d"
 	p_types = list(P_TYPE_ELEC)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/mightyena
 	name = "mightyena"
@@ -603,6 +659,7 @@
 	icon_living = "mightyena"
 	icon_dead = "mightyena"
 	p_types = list(P_TYPE_DARK)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/miltank
 	name = "miltank"
@@ -642,6 +699,7 @@
 	icon_dead = "poochyena_d"
 	p_types = list(P_TYPE_DARK)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/sylveon
 	name = "sylveon"
@@ -653,6 +711,7 @@
 	response_harm   = "hits"
 	p_types = list(P_TYPE_FAIRY)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/umbreon
 	name = "umbreon"
@@ -661,6 +720,7 @@
 	icon_living = "umbreon"
 	p_types = list(P_TYPE_DARK)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/vulpix
 	name = "vulpix"
@@ -669,6 +729,7 @@
 	icon_dead = "vulpix_d"
 	p_types = list(P_TYPE_FIRE)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/tentacruel
 	name = "tentacruel"
@@ -677,6 +738,7 @@
 	icon_dead = "tentacruel_d"
 	movement_cooldown = 3
 	p_types = list(P_TYPE_WATER)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/thievul
 	name = "thievul"
@@ -685,6 +747,7 @@
 	icon_dead = "thievul_d"
 	p_types = list(P_TYPE_DARK)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/ninetales
 	name = "ninetales"
@@ -693,6 +756,7 @@
 	icon_dead = "ninetales_d"
 	p_types = list(P_TYPE_FIRE)
 	additional_moves = list(/mob/living/simple_mob/animal/passive/pokemon/proc/move_telepathy)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/ponyta
 	name = "ponyta"
@@ -700,6 +764,7 @@
 	icon_living = "ponyta"
 	icon_dead = "ponyta_d"
 	p_types = list(P_TYPE_FIRE)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/zubat
 	name = "zubat"
@@ -708,6 +773,7 @@
 	icon_dead = "zubat_d"
 	desc = "Even though it has no eyes, it can sense obstacles using ultrasonic waves it emits from its mouth."
 	p_types = list(P_TYPE_FLY, P_TYPE_POISON)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/tangela
 	name = "tangela"
@@ -715,6 +781,7 @@
 	icon_living = "tangela"
 	icon_dead = "tangela_d"
 	p_types = list(P_TYPE_GRASS, P_TYPE_POISON)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/pinsir
 	name = "pinsir"
@@ -731,6 +798,7 @@
 	movement_cooldown = 3
 	p_types = list(P_TYPE_ROCK, P_TYPE_WATER)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/magmar
 	name = "magmar"
@@ -748,6 +816,8 @@
 	movement_cooldown = 5
 	p_types = list(P_TYPE_WATER)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/lapras
 	name = "lapras"
@@ -756,6 +826,7 @@
 	icon_dead = "lapras_d"
 	movement_cooldown = 3
 	p_types = list(P_TYPE_WATER)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/kabuto
 	name = "kabuto"
@@ -771,6 +842,7 @@
 	icon_living = "Aerodactyl"
 	icon_dead = "Aerodactyl_d"
 	p_types = list(P_TYPE_ROCK, P_TYPE_FLY)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/lickitung
 	name = "lickitung"
@@ -786,6 +858,7 @@
 	icon_dead = "cubone_d"
 	p_types = list(P_TYPE_GROUND)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/mew
 	name = "mew"
@@ -797,6 +870,7 @@
 							/mob/living/simple_mob/animal/passive/pokemon/proc/move_hover,
 							/mob/living/simple_mob/animal/passive/pokemon/proc/move_imposter,
 							/mob/living/simple_mob/animal/passive/pokemon/proc/move_invisibility)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/mewtwo
 	name = "mewtwo"
@@ -814,6 +888,7 @@
 	icon_dead = "purrloin_d"
 	p_types = list(P_TYPE_DARK)
 	additional_moves = list(/mob/living/proc/hide)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/ralts
 	name = "ralts"
@@ -821,6 +896,7 @@
 	icon_living = "ralts"
 	icon_dead = "ralts_d"
 	p_types = list(P_TYPE_PSYCH, P_TYPE_FAIRY)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/snorlax
 	name = "snorlax"
@@ -828,6 +904,7 @@
 	icon_living = "snorlax"
 	icon_dead = "snorlax_d"
 	p_types = list(P_TYPE_NORM)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/vaporeon
 	name = "vaporeon"
@@ -835,6 +912,7 @@
 	icon_living = "vaporeon"
 	icon_dead = "vaporeon_d"
 	p_types = list(P_TYPE_WATER)
+	p_traits = list(P_TRAIT_RIDEABLE)
 
 /mob/living/simple_mob/animal/passive/pokemon/zigzagoon
 	name = "zigzagoon"
@@ -843,6 +921,8 @@
 	icon_dead = "zigzagoon_d"
 	p_types = list(P_TYPE_NORM)
 	additional_moves = list(/mob/living/proc/hide)
+	p_traits = list(P_TRAIT_RIDEABLE)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/zoroark
 	name = "zoroark"
@@ -859,6 +939,7 @@
 	icon_dead = "zorua_d"
 	p_types = list(P_TYPE_DARK)
 	additional_moves = list(/mob/living/proc/hide, /mob/living/simple_mob/animal/passive/pokemon/proc/move_imposter)
+	mob_size = MOB_SMALL
 
 /mob/living/simple_mob/animal/passive/pokemon/zorua_hisuian
 	name = "hisuian zorua"
@@ -868,6 +949,7 @@
 	tt_desc = "hisuian zorua"
 	p_types = list(P_TYPE_NORM, P_TYPE_GHOST)
 	additional_moves = list(/mob/living/proc/hide, /mob/living/simple_mob/animal/passive/pokemon/proc/move_imposter)
+	mob_size = MOB_SMALL
 
 ///////////////////////
 //ALPHABETICAL PLEASE//

--- a/content_arfs/code/mob/pokemon.dm
+++ b/content_arfs/code/mob/pokemon.dm
@@ -74,8 +74,8 @@
 		sleeping--
 		if(sleeping <= 0)
 			sleeping = 0
-		update_canmove()
-		update_icon()
+	update_canmove()
+	update_icon()
 	return TRUE
 
 /mob/living/simple_mob/animal/passive/pokemon/death(gibbed,deathmessage="seizes up and falls limp...")
@@ -170,6 +170,13 @@
 	pixel_y = old_y
 	cut_overlay(r_hand_sprite)	//Hand sprites don't line up with the mob, just hide them
 	cut_overlay(l_hand_sprite)
+	//update_icon is called when you pick something up or drop it anyways, so this goes here
+	if(istype(r_hand,/obj/item/weapon/card/id))
+		myid = r_hand
+	else if(istype(l_hand,/obj/item/weapon/card/id))
+		myid = l_hand
+	else
+		myid = null
 
 /mob/living/simple_mob/animal/passive/pokemon/resize(new_size, animate = TRUE, uncapped = FALSE, ignore_prefs = FALSE, aura_animation = TRUE)
 	. = ..()

--- a/content_arfs/code/mob/pokemon_riding.dm
+++ b/content_arfs/code/mob/pokemon_riding.dm
@@ -1,0 +1,64 @@
+/datum/riding/pokemon
+	keytype = /obj/item/weapon/material/twohanded/riding_crop
+	nonhuman_key_exemption = FALSE
+	key_name = "a riding crop"
+	only_one_driver = TRUE
+/*
+/datum/riding/pokemon/handle_vehicle_layer()
+	ridden.layer = initial(ridden.layer)
+*/
+/datum/riding/pokemon/ride_check(mob/living/M)
+	var/mob/living/L = ridden
+	if(L.stat)
+		force_dismount(M)
+		return FALSE
+	return TRUE
+
+/datum/riding/pokemon/force_dismount(mob/M)
+	. =..()
+	ridden.visible_message("<span class='notice'>[M] stops riding [ridden]!</span>")
+
+/mob/living/simple_mob/animal/passive/pokemon/buckle_mob(mob/living/M, forced = FALSE, check_loc = TRUE)
+	if(forced)
+		return ..() // Skip our checks
+	if(!(P_TRAIT_RIDEABLE in p_traits))
+		return FALSE
+	if(lying)
+		return FALSE
+	if(M in buckled_mobs)
+		return FALSE
+	if((M.size_multiplier * M.mob_size) > ((size_multiplier * mob_size) * 1.2))//Account for mob size
+		to_chat(src, "<span class='warning'>This isn't a pony show! You need to be bigger for them to ride.</span>")
+		return FALSE
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+
+		if(istaurtail(H.tail_style))
+			to_chat(src, "<span class='warning'>Too many legs. TOO MANY LEGS!!</span>")
+			return FALSE
+
+	if(M.loc != src.loc)
+		if(M.Adjacent(src))
+			M.forceMove(get_turf(src))
+
+	. = ..()
+	if(.)
+		riding_datum.rider_size = M.size_multiplier
+		buckled_mobs[M] = "riding"
+
+/mob/living/simple_mob/animal/passive/pokemon/proc/riding_mount(var/mob/living/M in living_mobs(1))
+	set name = "Mount/Dismount"
+	set category = "Abilities"
+	set desc = "Let people ride on you."
+
+	if(LAZYLEN(buckled_mobs))
+		var/datum/riding/R = riding_datum
+		for(var/rider in buckled_mobs)
+			R.force_dismount(rider)
+		return
+	if (stat != CONSCIOUS)
+		return
+	if(!can_buckle || !istype(M) || !M.Adjacent(src) || M.buckled)
+		return
+	if(buckle_mob(M))
+		visible_message("<span class='notice'>[M] starts riding [name]!</span>")

--- a/content_arfs/code/mob/pokemon_riding.dm
+++ b/content_arfs/code/mob/pokemon_riding.dm
@@ -27,7 +27,7 @@
 		return FALSE
 	if(M in buckled_mobs)
 		return FALSE
-	if((M.size_multiplier * M.mob_size) > ((size_multiplier * mob_size) * 1.2))//Account for mob size
+	if((M.size_multiplier * M.mob_size) > ((size_multiplier * mob_size) * 1.4))//Account for mob size
 		to_chat(src, "<span class='warning'>This isn't a pony show! You need to be bigger for them to ride.</span>")
 		return FALSE
 	if(ishuman(M))

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -6442,7 +6442,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "amU" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -11829,6 +11829,10 @@
 	dir = 10
 	},
 /obj/machinery/light,
+/obj/machinery/computer/guestpass{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration/hallway)
 "axc" = (
@@ -17170,7 +17174,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
+/area/exploration/waiting_room)
 "aHx" = (
 /turf/simulated/wall,
 /area/rnd/mixing)
@@ -21431,9 +21435,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"aRs" = (
-/turf/simulated/wall,
-/area/space)
 "aRt" = (
 /turf/simulated/open,
 /area/medical/medbay)
@@ -22259,7 +22260,7 @@
 "aTv" = (
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
+/area/exploration/waiting_room)
 "aTw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -22640,7 +22641,7 @@
 "aUo" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "aUq" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance,
@@ -24064,7 +24065,7 @@
 "aXD" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
-/area/hallway/primary/deckthree/aft)
+/area/exploration/gear)
 "aXE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -25350,9 +25351,29 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
 "blM" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/space)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/fancy_shuttle{
+	fancy_shuttle_tag = "explo"
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/computer/guestpass{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/steel,
+/area/shuttle/excursion/general)
 "bmh" = (
 /obj/machinery/atmospherics/portables_connector/fuel{
 	dir = 1
@@ -25904,14 +25925,10 @@
 "dkj" = (
 /turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
-"dkx" = (
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/space)
 "doV" = (
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "dpy" = (
 /obj/machinery/camera/autoname{
@@ -25952,7 +25969,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood,
-/area/space)
+/area/hallway/primary/deckthree/aft)
 "dIB" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_external/public{
@@ -26034,14 +26051,23 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_w)
 "dTp" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/engineering)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/computer/guestpass{
+	dir = 4;
+	pixel_x = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "dTL" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "dVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
@@ -26582,7 +26608,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "ftC" = (
 /obj/machinery/light{
 	dir = 4
@@ -27185,7 +27211,7 @@
 /obj/effect/floor_decal/rust,
 /obj/item/clothing/head/collectable/petehat,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "hFL" = (
 /obj/random/pottedplant,
 /obj/machinery/firealarm{
@@ -27395,7 +27421,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "inm" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -27593,7 +27619,7 @@
 /obj/effect/floor_decal/rust,
 /obj/item/clothing/mask/mouthwheat,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "iMp" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
 /turf/simulated/floor/tiled/dark,
@@ -27625,10 +27651,6 @@
 /obj/effect/floor_decal/corner/yellow/border,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
-"iQz" = (
-/obj/random/junk,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/engineering)
 "iUf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27690,10 +27712,6 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"jmT" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/space)
 "jnM" = (
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
@@ -27984,7 +28002,7 @@
 "knz" = (
 /obj/random/maintenance/engineering,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "kof" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28141,6 +28159,10 @@
 	},
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 10
+	},
+/obj/machinery/computer/guestpass{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -28768,7 +28790,7 @@
 /area/maintenance/security_port)
 "nhQ" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "njf" = (
 /obj/machinery/light/small{
@@ -28968,7 +28990,7 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "nQP" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -28989,7 +29011,7 @@
 /area/maintenance/station/deck_three/port_docking_arm)
 "obj" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "odu" = (
 /obj/structure/table/reinforced{
@@ -29184,7 +29206,7 @@
 "oHr" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood,
-/area/space)
+/area/hallway/primary/deckthree/aft)
 "oJO" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -29293,14 +29315,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard_airlock_n)
-"pkb" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/engineering)
 "plb" = (
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/engineering)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/machinery/computer/guestpass{
+	dir = 4;
+	pixel_x = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "plc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorblack{
@@ -29417,7 +29444,7 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "pEz" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -29926,7 +29953,7 @@
 /obj/structure/table/woodentable,
 /obj/random/maintenance/foodstuff,
 /turf/simulated/floor/wood,
-/area/space)
+/area/hallway/primary/deckthree/aft)
 "rlq" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -29990,18 +30017,10 @@
 /obj/structure/railing/grey,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/thrusters)
-"rtN" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/space)
 "rvM" = (
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
-/area/space)
-"rwQ" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "ryT" = (
 /obj/structure/table/reinforced,
 /obj/random/maintenance/foodstuff,
@@ -30025,10 +30044,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
-"rBH" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/airless/ceiling,
-/area/maintenance/engineering)
 "rFg" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/borderfloorblack{
@@ -30048,7 +30063,7 @@
 /area/maintenance/station/deck_three/port_docking_arm)
 "rHd" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "rJo" = (
 /obj/machinery/alarm{
@@ -30062,7 +30077,7 @@
 /area/hallway/station/docking_hall)
 "rKr" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "rNP" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -30139,7 +30154,7 @@
 /obj/effect/floor_decal/rust,
 /obj/item/clothing/under/suit_jacket/gambler,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "sfJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -30842,7 +30857,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/engineering)
 "uXm" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/yellow/border,
@@ -61123,7 +61138,7 @@ jzQ
 uXm
 ath
 knz
-rBH
+pmr
 aVi
 atm
 azg
@@ -61378,8 +61393,8 @@ bSh
 fot
 jzQ
 uXm
-pkb
-dTp
+ilZ
+aAH
 rHd
 aVi
 aVi
@@ -61894,7 +61909,7 @@ jzQ
 ogf
 ath
 ath
-dTp
+aAH
 aVi
 atm
 aBM
@@ -62151,7 +62166,7 @@ jzQ
 odW
 ath
 nhQ
-iQz
+sjK
 aVi
 atm
 aBP
@@ -62665,7 +62680,7 @@ rlZ
 emY
 ath
 obj
-dTp
+aAH
 aVi
 atm
 aCp
@@ -63179,7 +63194,7 @@ jzQ
 uXm
 ath
 knz
-plb
+fFt
 aVi
 atm
 aCy
@@ -63434,8 +63449,8 @@ bSh
 fot
 jzQ
 uXm
-pkb
-plb
+ilZ
+fFt
 rHd
 aVi
 asG
@@ -63646,7 +63661,7 @@ apC
 apC
 ajh
 apC
-apC
+dTp
 apC
 apC
 apC
@@ -63665,7 +63680,7 @@ uPZ
 mRx
 ppc
 gfR
-gfR
+plb
 gfR
 gfR
 eVI
@@ -63682,7 +63697,7 @@ mRx
 ivP
 meR
 gfR
-gfR
+plb
 gfR
 aEa
 ppc
@@ -63692,7 +63707,7 @@ gTR
 jzQ
 iQh
 ath
-plb
+fFt
 doV
 aVi
 asG
@@ -64425,43 +64440,43 @@ aLq
 apM
 aDY
 aDf
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
-axA
+aLJ
+aLJ
+aLJ
+aLJ
+aLJ
+aLJ
+aLJ
+aLJ
+aLJ
+asX
+asX
 aHw
 aTv
-axA
-axA
+asX
+asX
 qzE
 qzE
 qzE
-ajF
-ajF
-ajF
-kqO
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-ajF
-kqO
-ajF
-ajF
-ajF
+ath
+ath
+ath
+ilZ
+ath
+ath
+ath
+ath
+ath
+ath
+ath
+ath
+ath
+ath
+ath
+ilZ
+ath
+ath
+ath
 axA
 aGj
 aNJ
@@ -64682,7 +64697,7 @@ aMa
 aMa
 aMJ
 aON
-axA
+aLJ
 akB
 aOQ
 apJ
@@ -64700,24 +64715,24 @@ asX
 oHr
 rlg
 dBB
-aRs
-blM
+ath
+nhQ
 dTL
-rtN
+aAH
 aUo
-aRs
-rwQ
-dkx
-aIm
-aIm
+ath
+pmr
+sjK
+fFt
+fFt
 ftm
-aIm
-rtN
-aIm
-dkx
+fFt
+aAH
+fFt
+sjK
 dTL
-rtN
-aIm
+aAH
+fFt
 nQF
 aFv
 aGj
@@ -64939,7 +64954,7 @@ aMa
 aMa
 aMJ
 aON
-axA
+aLJ
 ayI
 axi
 axi
@@ -64954,26 +64969,26 @@ aWy
 ato
 aUO
 asX
-aRs
-aRs
-aRs
-aRs
-jmT
-aIm
-rtN
-dkx
+ath
+ath
+ath
+ath
+rKr
+fFt
+aAH
+sjK
 ilZ
-aIm
-rtN
-aIm
-aRs
-aRs
-aRs
-aRs
-aRs
-aIm
-aIm
-aIm
+fFt
+aAH
+fFt
+ath
+ath
+ath
+ath
+ath
+fFt
+fFt
+fFt
 dTL
 pEl
 aFv
@@ -65211,28 +65226,28 @@ anV
 awK
 aJb
 asX
-aIm
-rtN
+fFt
+aAH
 ftm
-aIm
-dkx
-aIm
+fFt
+sjK
+fFt
 uUH
-aIm
-aRs
-rtN
-dkx
+fFt
+ath
+aAH
+sjK
 pEl
-aRs
+ath
 hDL
 iMf
 saB
-aRs
-rwQ
+ath
+pmr
 amT
 rvM
-aIm
-rtN
+fFt
+aAH
 aFv
 aGj
 aSw
@@ -65453,7 +65468,7 @@ aMa
 aMa
 aMa
 aMa
-axA
+aLJ
 aEz
 awm
 apr
@@ -65710,7 +65725,7 @@ aMa
 awe
 aMa
 aMa
-axA
+aLJ
 aDc
 anJ
 aWj
@@ -65967,7 +65982,7 @@ ajF
 ajF
 ajF
 ajF
-axA
+aLJ
 aCn
 aSC
 aSC
@@ -66221,10 +66236,10 @@ alU
 aww
 aOw
 aoJ
-aRs
+aHx
 aoo
 aoo
-aFZ
+aLJ
 aQm
 azI
 azI
@@ -66478,10 +66493,10 @@ aJw
 avh
 aSz
 aWT
-aRs
+aHx
 aoo
 aoo
-aFZ
+aLJ
 aLQ
 axi
 axi
@@ -66735,10 +66750,10 @@ alU
 aIQ
 apI
 alB
-aRs
+aHx
 aoo
 aoo
-aFZ
+aLJ
 alo
 arM
 arM
@@ -66995,7 +67010,7 @@ aYE
 aYE
 aoo
 aoo
-aFZ
+aLJ
 aJc
 axi
 axi
@@ -67252,7 +67267,7 @@ aMX
 aYE
 aoo
 aoo
-aFZ
+aLJ
 aqZ
 axi
 axi
@@ -67509,7 +67524,7 @@ aCv
 aYE
 aoo
 aoo
-aFZ
+aLJ
 awI
 aPW
 aos
@@ -67766,9 +67781,9 @@ aCS
 aYE
 aoo
 aoo
-aFZ
-aFZ
-aFZ
+aLJ
+aLJ
+aLJ
 asi
 asi
 aHl
@@ -68050,7 +68065,7 @@ amv
 aoR
 aks
 aqV
-asg
+blM
 alO
 alO
 auf

--- a/maps/Arfs/arfs-3-deckthree.dmm
+++ b/maps/Arfs/arfs-3-deckthree.dmm
@@ -12184,9 +12184,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
-"axA" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/primary/deckthree/aft)
 "axB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/window/reinforced,
@@ -12708,9 +12705,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/locker/upper)
 "ayA" = (
-/obj/machinery/atmospherics/pipe/tank/phoron,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/tank/phoron{
+	name = "High Pressure Tank (Phoron)";
+	volume = 100000
 	},
 /turf/simulated/floor/plating,
 /area/exploration/hanger)
@@ -16604,7 +16604,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/cmostore)
 "aGj" = (
-/obj/machinery/atmospherics/pipe/tank/phoron,
+/obj/machinery/atmospherics/pipe/tank/phoron{
+	name = "High Pressure Tank (Phoron)";
+	volume = 100000
+	},
 /turf/simulated/floor/plating,
 /area/exploration/hanger)
 "aGk" = (
@@ -25351,31 +25354,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_starboard_airlock_n)
 "blM" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/fancy_shuttle{
-	fancy_shuttle_tag = "explo"
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/machinery/computer/guestpass{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/steel,
-/area/shuttle/excursion/general)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "bmh" = (
-/obj/machinery/atmospherics/portables_connector/fuel{
+/obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -25968,7 +25951,7 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/hallway/primary/deckthree/aft)
 "dIB" = (
 /obj/machinery/door/firedoor/glass,
@@ -26050,19 +26033,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/station/docking_hall_airlock_w)
-"dTp" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/computer/guestpass{
-	dir = 4;
-	pixel_x = -25
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
 "dTL" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
@@ -27651,6 +27621,12 @@
 /obj/effect/floor_decal/corner/yellow/border,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
+"iQz" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/exploration/hanger)
 "iUf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27712,6 +27688,19 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"jmT" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/computer/guestpass{
+	dir = 4;
+	pixel_x = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
 "jnM" = (
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/dark,
@@ -28788,10 +28777,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"nhQ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/maintenance/engineering)
 "njf" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -29205,7 +29190,7 @@
 /area/maintenance/medbay_aft)
 "oHr" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/hallway/primary/deckthree/aft)
 "oJO" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -29315,19 +29300,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docking_hall_starboard_airlock_n)
-"plb" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+"pkb" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/fancy_shuttle{
+	fancy_shuttle_tag = "explo"
+	},
+/obj/structure/handrail{
+	dir = 1
 	},
 /obj/machinery/computer/guestpass{
-	dir = 4;
-	pixel_x = -25
+	dir = 1;
+	pixel_y = -25
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/deckthree/aft)
+/turf/simulated/floor/tiled/steel,
+/area/shuttle/excursion/general)
 "plc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorblack{
@@ -29758,7 +29754,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
 "qzE" = (
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/obj/random/maintenance/foodstuff,
+/turf/simulated/floor/carpet,
 /area/hallway/primary/deckthree/aft)
 "qBu" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -29951,8 +29949,7 @@
 /area/maintenance/security_port)
 "rlg" = (
 /obj/structure/table/woodentable,
-/obj/random/maintenance/foodstuff,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/hallway/primary/deckthree/aft)
 "rlq" = (
 /obj/machinery/power/apc{
@@ -30041,6 +30038,19 @@
 	},
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/deckthree/aft)
+"rBH" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/machinery/computer/guestpass{
+	dir = 4;
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/deckthree/aft)
@@ -62165,7 +62175,7 @@ fot
 jzQ
 odW
 ath
-nhQ
+blM
 sjK
 aVi
 atm
@@ -63661,7 +63671,7 @@ apC
 apC
 ajh
 apC
-dTp
+jmT
 apC
 apC
 apC
@@ -63680,7 +63690,7 @@ uPZ
 mRx
 ppc
 gfR
-plb
+rBH
 gfR
 gfR
 eVI
@@ -63697,7 +63707,7 @@ mRx
 ivP
 meR
 gfR
-plb
+rBH
 gfR
 aEa
 ppc
@@ -63963,7 +63973,7 @@ aBH
 aBx
 enG
 uXm
-axA
+aFv
 aFv
 aFv
 aFv
@@ -64220,7 +64230,7 @@ dKX
 kvk
 pBI
 snD
-axA
+aFv
 ayA
 vVs
 ffX
@@ -64455,9 +64465,9 @@ aHw
 aTv
 asX
 asX
+oHr
 qzE
-qzE
-qzE
+dBB
 ath
 ath
 ath
@@ -64477,11 +64487,11 @@ ilZ
 ath
 ath
 ath
-axA
+aFv
 aGj
 aNJ
 aEn
-aKe
+iQz
 aKe
 aFv
 alc
@@ -64716,7 +64726,7 @@ oHr
 rlg
 dBB
 ath
-nhQ
+blM
 dTL
 aAH
 aUo
@@ -68065,7 +68075,7 @@ amv
 aoR
 aks
 aqV
-blM
+pkb
 alO
 alO
 auf

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4169,6 +4169,7 @@
 #include "content_arfs\code\mob\playable_changeling.dm"
 #include "content_arfs\code\mob\pokemon.dm"
 #include "content_arfs\code\mob\pokemon_moves.dm"
+#include "content_arfs\code\mob\pokemon_riding.dm"
 #include "content_arfs\code\mob\sprite_accessories_arf.dm"
 #include "content_arfs\code\mob\verbs_arf.dm"
 #include "content_arfs\code\mob\vox_overrides.dm"


### PR DESCRIPTION
Adds Pokemon riding functionality
Adds Pokemon Trait system
Adds guest pass terminals around, inside, and even nearby to the exploration shuttle, prep, and construction site on deck 3
Fixed maint tunnel bugs on deck 3 aft section
Fixes exploration fuel storage's issues
Allows pokemon with an ID card in their hands to operate ID-restricted machines/interfaces