### PR TITLE
Lowers init times

### DIFF
--- a/code/__defines/arfs_defines.dm
+++ b/code/__defines/arfs_defines.dm
@@ -2,6 +2,7 @@
 
 #define ispokemon(A)		istype(A, /mob/living/simple_mob/animal/passive/pokemon)
 #define islegendary(A)		istype(A, /mob/living/simple_mob/animal/passive/pokemon/leg)
+#define islegendarypath(P)	ispath(P, /mob/living/simple_mob/animal/passive/pokemon/leg)
 
 #define P_TYPE_FIRE 	"fire"
 #define P_TYPE_WATER 	"water"

--- a/code/__defines/rust_g_overrides.dm
+++ b/code/__defines/rust_g_overrides.dm
@@ -1,0 +1,3 @@
+// RUSTG_OVERRIDE_BUILTINS is not used since the file APIs don't work well over Linux.
+#define url_encode(text) rustg_url_encode("[text]")
+#define url_decode(text) rustg_url_decode("[text]")

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -149,7 +149,7 @@ var/list/mining_overlay_cache = list()
 /turf/simulated/mineral/floor/ignore_mapgen
 	ignore_mapgen = 1
 
-/turf/simulated/mineral/proc/make_floor()
+/turf/simulated/mineral/proc/make_floor(update_neighbors)
 	if(!density && !opacity)
 		return
 	density = FALSE
@@ -157,7 +157,7 @@ var/list/mining_overlay_cache = list()
 	blocks_air = 0
 	can_build_into_floor = TRUE
 	clear_ore_effects()
-	update_general()
+	update_general(update_neighbors)
 
 /turf/simulated/mineral/proc/make_wall()
 	if(density && opacity)
@@ -168,8 +168,8 @@ var/list/mining_overlay_cache = list()
 	can_build_into_floor = FALSE
 	update_general()
 
-/turf/simulated/mineral/proc/update_general()
-	update_icon(1)
+/turf/simulated/mineral/proc/update_general(update_neighbors = TRUE)
+	update_icon(update_neighbors)
 	recalculate_directional_opacity()
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
 		reconsider_lights()
@@ -676,15 +676,17 @@ var/list/mining_overlay_cache = list()
 				new /obj/item/stack/material/uranium(src, rand(5,25))
 
 /turf/simulated/mineral/proc/make_ore(var/rare_ore)
+	var/static/list/minerals = list("marble" = 3,/* "quartz" = 10, "copper" = 20, "tin" = 15, "bauxite" = 15*/, "uranium" = 10, "platinum" = 10, "hematite" = 70, "rutile" = 15, "carbon" = 70, "diamond" = 2, "gold" = 10, "silver" = 10, "phoron" = 20, "lead" = 3,/* "void opal" = 1,*/ "verdantium" = 1/*, "painite" = 1*/)
+	var/static/list/rare_minerals = list("marble" = 5,/* "quartz" = 15, "copper" = 10, "tin" = 5, "bauxite" = 5*/, "uranium" = 15, "platinum" = 20, "hematite" = 15, "rutile" = 20, "carbon" = 15, "diamond" = 3, "gold" = 15, "silver" = 15, "phoron" = 25, "lead" = 5,/* "void opal" = 1,*/ "verdantium" = 2/*, "painite" = 1*/)
 	if(mineral || ignore_mapgen || ignore_oregen) //VOREStation Edit - Makes sense, doesn't it?
 		return
 
 	var/mineral_name
 	if(rare_ore)
-		mineral_name = pickweight(list("marble" = 5,/* "quartz" = 15, "copper" = 10, "tin" = 5, "bauxite" = 5*/, "uranium" = 15, "platinum" = 20, "hematite" = 15, "rutile" = 20, "carbon" = 15, "diamond" = 3, "gold" = 15, "silver" = 15, "phoron" = 25, "lead" = 5,/* "void opal" = 1,*/ "verdantium" = 2/*, "painite" = 1*/))
+		mineral_name = pickweight(rare_minerals)
 
 	else
-		mineral_name = pickweight(list("marble" = 3,/* "quartz" = 10, "copper" = 20, "tin" = 15, "bauxite" = 15*/, "uranium" = 10, "platinum" = 10, "hematite" = 70, "rutile" = 15, "carbon" = 70, "diamond" = 2, "gold" = 10, "silver" = 10, "phoron" = 20, "lead" = 3,/* "void opal" = 1,*/ "verdantium" = 1/*, "painite" = 1*/))
+		mineral_name = pickweight(minerals)
 
 	if(mineral_name && (mineral_name in GLOB.ore_data))
 		mineral = GLOB.ore_data[mineral_name]

--- a/code/modules/random_map/automata/caves.dm
+++ b/code/modules/random_map/automata/caves.dm
@@ -59,7 +59,7 @@
 	if(istype(T) && !T.ignore_mapgen)
 		if(!T.ignore_cavegen)
 			if(map[current_cell] == FLOOR_CHAR)
-				T.make_floor()
+				T.make_floor(FALSE)
 			else
 				T.make_wall()
 

--- a/content_arfs/code/ghost_pods_arfs.dm
+++ b/content_arfs/code/ghost_pods_arfs.dm
@@ -36,10 +36,8 @@ var/global/list/pokemon_pods = list()//List of pods that ghosts can spawn at
 	if(LAZYLEN(pokemon_choices_list))
 		return FALSE	//The global list is already generated
 	var/pokemon_choices_list_paths = typesof(/mob/living/simple_mob/animal/passive/pokemon) - remove_paths
-	for (var/path in pokemon_choices_list_paths)//add the mobs to a list with their names referencing paths
-		var/mob/living/simple_mob/animal/passive/pokemon/P = new path()
-		pokemon_choices_list["[P.name]"] = P.type
-		del(P)
+	for (var/mob/living/simple_mob/animal/passive/pokemon/path in pokemon_choices_list_paths)//add the mobs to a list with their names referencing paths
+		pokemon_choices_list["[initial(path.name)]"] = path
 
 /obj/structure/ghost_pod/manual/attack_hand(var/mob/user)
 	//Inform curious minds about how to use this.

--- a/content_arfs/code/mob/pokemon_moves.dm
+++ b/content_arfs/code/mob/pokemon_moves.dm
@@ -401,17 +401,19 @@
 		return
 	new_size_mult = clamp(new_size_mult, RESIZE_MINIMUM, RESIZE_MAXIMUM)
 	p_choice = pokemon_choices_list["[p_choice]"]
-	var/mob/living/simple_mob/animal/passive/pokemon/NP = new p_choice()
+	var/mob/living/simple_mob/animal/passive/pokemon/NP = p_choice
 	gender 			= 	new_gender
-	icon 			= 	NP.icon
-	icon_state 		= 	NP.icon_state
-	icon_living		=	NP.icon_living
-	icon_dead		= 	"[NP.icon_state]_d"
-	icon_rest		= 	"[NP.icon_state]_rest"
-	tt_desc			=	NP.tt_desc
-	y_offset_mult	=	NP.y_offset_mult
+	icon 			= 	initial(NP.icon)
+	icon_state 		= 	initial(NP.icon_state)
+	tt_desc			=	initial(NP.tt_desc)
+	if(!tt_desc)
+		tt_desc = capitalize(icon_state)
+	icon_living		=	initial(NP.icon_living)
+	icon_dead		= 	"[icon_state]_d"
+	icon_rest		= 	"[icon_state]_rest"
+	y_offset_mult	=	initial(NP.y_offset_mult)
 	resize(new_size_mult)
-	if(islegendary(NP))
+	if(islegendarypath(NP))
 		pixel_x = -32
 		default_pixel_x = -32
 		old_x = -32
@@ -419,13 +421,13 @@
 		pixel_x = -16
 		default_pixel_x = -16
 		old_x = -16
-	visible_message("<span class='notice'>[src] slowly transforms until they look just like a [NP.name]!</span>")
-	to_chat(src,"<span class='green'><i>You've transformed to look like a [NP.name]! You can set your flavor text by using the Set Flavortext verb to match your new appearance.</i></span>")
-	if(NP.type != src.type)//Did we transform into a non-ditto?
+	var/NPname = initial(NP.name)
+	visible_message("<span class='notice'>[src] slowly transforms until they look just like a [NPname]!</span>")
+	to_chat(src,"<span class='green'><i>You've transformed to look like a [NPname]! You can set your flavor text by using the Set Flavortext verb to match your new appearance.</i></span>")
+	if(p_choice != src.type)//Did we transform into a non-ditto?
 		active_moves |= M_TF //Add the transformed active move
 	else
 		active_moves -= M_TF //Otherwise remove it
-	del(NP)
 	move_cooldown = TRUE
 	spawn(move_cooldown_time*6)//60s
 		move_cooldown = FALSE

--- a/maps/Arfs/submaps/aerostat/_aerostat_science_outpost.dm
+++ b/maps/Arfs/submaps/aerostat/_aerostat_science_outpost.dm
@@ -147,38 +147,41 @@ VIRGO2_TURF_CREATE(/turf/simulated/floor/tiled/techfloor)
 VIRGO2_TURF_CREATE(/turf/simulated/mineral)
 /////Copied from Virgo3b's ore generation, since there was concern about not being able to get the ore they need on V2
 /turf/simulated/mineral/virgo2/make_ore(var/rare_ore)
+	var/static/list/minerals = list(
+		"marble" = 2,
+		"uranium" = 5,
+		"platinum" = 5,
+		"hematite" = 35,
+		"carbon" = 35,
+		"gold" = 3,
+		"silver" = 3,
+		"phoron" = 25,
+		"lead" = 1)
+	var/static/list/rare_minerals = list(
+		"marble" = 3,
+		"uranium" = 10,
+		"platinum" = 10,
+		"hematite" = 20,
+		"carbon" = 20,
+		"diamond" = 1,
+		"gold" = 8,
+		"silver" = 8,
+		"phoron" = 18,
+		"lead" = 2,
+		"verdantium" = 1)
 	if(mineral)
 		return
 	var/mineral_name
 	if(rare_ore)
-		mineral_name = pickweight(list(
-			"marble" = 3,
-			"uranium" = 10,
-			"platinum" = 10,
-			"hematite" = 20,
-			"carbon" = 20,
-			"diamond" = 1,
-			"gold" = 8,
-			"silver" = 8,
-			"phoron" = 18,
-			"lead" = 2,
-			"verdantium" = 1))
+		mineral_name = pickweight(rare_minerals)
 	else
-		mineral_name = pickweight(list(
-			"marble" = 2,
-			"uranium" = 5,
-			"platinum" = 5,
-			"hematite" = 35,
-			"carbon" = 35,
-			"gold" = 3,
-			"silver" = 3,
-			"phoron" = 25,
-			"lead" = 1))
+		mineral_name = pickweight(minerals)
 
 	if(mineral_name && (mineral_name in GLOB.ore_data))
 		mineral = GLOB.ore_data[mineral_name]
 		UpdateMineral()
-	update_icon()
+	else // to avoid a redundant call after UpdateMineral
+		update_icon()
 
 VIRGO2_TURF_CREATE(/turf/simulated/mineral/ignore_mapgen)
 VIRGO2_TURF_CREATE(/turf/simulated/mineral/floor)

--- a/maps/Arfs/submaps/om_adventure/grasscave.dm
+++ b/maps/Arfs/submaps/om_adventure/grasscave.dm
@@ -49,33 +49,35 @@
 	initial_generic_waypoints = list("om-grasscave-center", "om-grasscave-southeast")
 
 /turf/simulated/mineral/omadventure/make_ore(var/rare_ore)
+	var/static/list/minerals = list(
+		"marble" = 3,
+		"uranium" = 10,
+		"platinum" = 10,
+		"hematite" = 20,
+		"carbon" = 30,
+		"diamond" = 20,
+		"gold" = 8,
+		"silver" = 8,
+		"phoron" = 18,
+		"lead" = 5,
+		"verdantium" = 5)
+	var/static/list/rare_minerals = list(
+		"marble" = 2,
+		"uranium" = 5,
+		"platinum" = 5,
+		"hematite" = 35,
+		"carbon" = 30,
+		"gold" = 3,
+		"silver" = 3,
+		"phoron" = 25,
+		"lead" = 1)
 	if(mineral)
 		return
 	var/mineral_name
 	if(rare_ore)
-		mineral_name = pickweight(list(
-			"marble" = 3,
-			"uranium" = 10,
-			"platinum" = 10,
-			"hematite" = 20,
-			"carbon" = 30,
-			"diamond" = 20,
-			"gold" = 8,
-			"silver" = 8,
-			"phoron" = 18,
-			"lead" = 5,
-			"verdantium" = 5))
+		mineral_name = pickweight(rare_minerals)
 	else
-		mineral_name = pickweight(list(
-			"marble" = 2,
-			"uranium" = 5,
-			"platinum" = 5,
-			"hematite" = 35,
-			"carbon" = 30,
-			"gold" = 3,
-			"silver" = 3,
-			"phoron" = 25,
-			"lead" = 1))
+		mineral_name = pickweight(minerals)
 
 	if(mineral_name && (mineral_name in GLOB.ore_data))
 		mineral = GLOB.ore_data[mineral_name]

--- a/maps/Arfs/submaps/space_rocks/space_rocks.dm
+++ b/maps/Arfs/submaps/space_rocks/space_rocks.dm
@@ -2,33 +2,35 @@
 #include "space_rocks_stuff.dm"
 
 /turf/simulated/mineral/vacuum/sdmine/make_ore(var/rare_ore)
+	var/static/list/minerals = list(
+		"marble" = 2,
+		"uranium" = 5,
+		"platinum" = 5,
+		"hematite" = 35,
+		"carbon" = 5,
+		"gold" = 3,
+		"silver" = 3,
+		"phoron" = 25,
+		"lead" = 1)
+	var/static/list/rare_minerals = list(
+		"marble" = 3,
+		"uranium" = 10,
+		"platinum" = 10,
+		"hematite" = 20,
+		"carbon" = 5,
+		"diamond" = 1,
+		"gold" = 8,
+		"silver" = 8,
+		"phoron" = 18,
+		"lead" = 2,
+		"verdantium" = 1)
 	if(mineral)
 		return
 	var/mineral_name
 	if(rare_ore)
-		mineral_name = pickweight(list(
-			"marble" = 3,
-			"uranium" = 10,
-			"platinum" = 10,
-			"hematite" = 20,
-			"carbon" = 5,
-			"diamond" = 1,
-			"gold" = 8,
-			"silver" = 8,
-			"phoron" = 18,
-			"lead" = 2,
-			"verdantium" = 1))
+		mineral_name = pickweight(rare_minerals)
 	else
-		mineral_name = pickweight(list(
-			"marble" = 2,
-			"uranium" = 5,
-			"platinum" = 5,
-			"hematite" = 35,
-			"carbon" = 5,
-			"gold" = 3,
-			"silver" = 3,
-			"phoron" = 25,
-			"lead" = 1))
+		mineral_name = pickweight(minerals)
 
 	if(mineral_name && (mineral_name in GLOB.ore_data))
 		mineral = GLOB.ore_data[mineral_name]

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -82,6 +82,7 @@
 #include "code\__defines\research.dm"
 #include "code\__defines\roguemining_vr.dm"
 #include "code\__defines\rust_g.dm"
+#include "code\__defines\rust_g_overrides.dm"
 #include "code\__defines\shields.dm"
 #include "code\__defines\shuttle.dm"
 #include "code\__defines\sound.dm"


### PR DESCRIPTION
Someone said y'all get 8-minute init times and that's just atrocious.
- Fixes issues with harddels caused by pokemon code. That avoids 62 instantiations and harddels per startup! It was 5 seconds on my machine but who knows how long it'd take on a live server; it's bound to help a ton.
- Avoids unnecessary/redundant update_icon calls in cave map generation.
- Saves some time in `make_ore` by avoiding repeated list re-instantiations.
- Enables some rust_g builtin function overrides for increased speed (TG does it, so it's probably fine).