### PR TITLE
More Solars, Lobby Screen Maybefix

### DIFF
--- a/maps/Arfs/arfs-1-deckone.dmm
+++ b/maps/Arfs/arfs-1-deckone.dmm
@@ -40,8 +40,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -59,8 +59,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/freezer{
@@ -196,8 +196,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -218,6 +218,38 @@
 	},
 /turf/simulated/floor/wood,
 /area/holodeck_control)
+"bc" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"bf" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/random/trash,
+/turf/simulated/floor/airless,
+/area/space)
 "bi" = (
 /obj/structure/sign/deck/first,
 /turf/simulated/wall,
@@ -282,6 +314,19 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library)
+"bw" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "bD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -411,17 +456,32 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "0-6"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
+"cq" = (
+/obj/item/weapon/reagent_containers/food/snacks/donkpocket/pizza,
+/obj/structure/catwalk,
+/turf/space,
+/area/space)
 "cs" = (
 /obj/machinery/seed_storage/garden,
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
+"cv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "cz" = (
 /obj/machinery/biogenerator,
 /turf/simulated/floor/tiled/kafel_full/green,
@@ -469,8 +529,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -483,6 +543,17 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/blue,
 /area/chapel/office)
+"cM" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/directions/ladder_up{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "cN" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -599,8 +670,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
@@ -718,6 +789,11 @@
 /obj/structure/bed/chair/sofa/right/black,
 /turf/simulated/floor/wood,
 /area/library)
+"eD" = (
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "eH" = (
 /obj/random/mob/fish,
 /obj/structure/flora/lily2,
@@ -821,8 +897,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1091,6 +1167,15 @@
 /obj/item/weapon/reagent_containers/glass/rag,
 /turf/simulated/floor/glass/reinforced,
 /area/crew_quarters/bar)
+"gX" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "gY" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -1113,6 +1198,20 @@
 	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
+"hb" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/random/trash,
+/turf/simulated/floor/airless,
+/area/space)
 "he" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/kitchenspike,
@@ -1194,8 +1293,8 @@
 /area/hydroponics/garden)
 "hz" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1217,6 +1316,25 @@
 /area/hallway/primary/central_one{
 	name = "\improper Central Primary Hallway - Lower"
 	})
+"hB" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/solar{
+	id = "dallus_belly_solars"
+	},
+/turf/simulated/floor/airless{
+	icon_state = "solarpanel"
+	},
+/area/space)
+"hF" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "hH" = (
 /obj/machinery/door/morgue{
 	dir = 2;
@@ -1225,6 +1343,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"hM" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "hN" = (
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Library, Fore";
@@ -1253,8 +1379,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -1484,6 +1610,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/chapel/office)
+"jz" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "jB" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/food/snacks/meat/chicken,
@@ -1624,6 +1757,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/holodeck_control)
+"kX" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "kY" = (
 /obj/machinery/computer/guestpass{
 	pixel_x = -28
@@ -1668,13 +1806,26 @@
 /area/hallway/primary/central_one{
 	name = "\improper Central Primary Hallway - Lower"
 	})
+"li" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "lj" = (
 /obj/effect/floor_decal/corner/lightgrey/diagonal{
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1713,8 +1864,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
@@ -2268,13 +2419,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
@@ -2404,6 +2560,16 @@
 /area/hallway/primary/central_one{
 	name = "\improper Central Primary Hallway - Lower"
 	})
+"oY" = (
+/obj/machinery/power/tracker{
+	id = "dallus_belly_solars"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "pa" = (
 /obj/machinery/door/blast/regular{
 	id = "chap"
@@ -2549,6 +2715,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/chapel/office)
+"pG" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/random/trash,
+/turf/simulated/floor/airless,
+/area/space)
 "pI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2802,8 +2987,8 @@
 	dir = 2
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood{
@@ -2818,6 +3003,18 @@
 	color = "#C04000"
 	},
 /area/library)
+"qZ" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar{
+	id = "dallus_belly_solars"
+	},
+/turf/simulated/floor/airless{
+	icon_state = "solarpanel"
+	},
+/area/space)
 "ra" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -2829,12 +3026,20 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"rd" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "rf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -2851,7 +3056,9 @@
 	name = "west bump";
 	pixel_x = -26
 	},
-/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "0-6"
+	},
 /turf/simulated/floor/wood{
 	color = "#C04000"
 	},
@@ -3139,6 +3346,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/chapel_morgue)
+"sY" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/toolbox/electrical,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "te" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass{
@@ -3166,6 +3383,13 @@
 "tp" = (
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/hydroponics)
+"tt" = (
+/obj/structure/ladder/up,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "tw" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin{
@@ -3210,14 +3434,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
@@ -3267,8 +3494,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/eris/cafe,
@@ -3326,6 +3553,24 @@
 	color = "#C04000"
 	},
 /area/library)
+"uC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "uE" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/machinery/camera/autoname{
@@ -3403,6 +3648,18 @@
 "vf" = (
 /turf/simulated/floor/water/indoors,
 /area/hydroponics/garden)
+"vg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Belly Solar Maintenance"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "vh" = (
 /mob/living/simple_mob/animal/passive/chick,
 /obj/machinery/light/floortube,
@@ -3568,6 +3825,10 @@
 /obj/machinery/clawmachine,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"wH" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "wI" = (
 /obj/effect/floor_decal/corner/lightgrey/diagonal{
 	dir = 8
@@ -3577,8 +3838,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3807,8 +4068,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3842,6 +4103,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"yx" = (
+/obj/structure/catwalk,
+/turf/space,
+/area/space)
 "yy" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn,
@@ -3851,6 +4116,21 @@
 /obj/effect/wingrille_spawn,
 /turf/simulated/floor/plating,
 /area/chapel/main)
+"yE" = (
+/obj/machinery/power/solar_control/autostart{
+	id = "dallus_belly_solars"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "yF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -4001,12 +4281,24 @@
 /area/hallway/primary/central_one{
 	name = "\improper Central Primary Hallway - Lower"
 	})
+"AF" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "AG" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/hydroponics)
+"AH" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "AK" = (
 /obj/effect/floor_decal/corner/lightgrey/diagonal{
 	dir = 8
@@ -4062,17 +4354,16 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/structure/disposalpipe/up{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 16;
 	d2 = 0;
 	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
@@ -4165,6 +4456,29 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
+"DX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "ET" = (
 /obj/effect/floor_decal/corner/lightgrey/diagonal{
 	dir = 8
@@ -4218,6 +4532,12 @@
 	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
+"FY" = (
+/obj/machinery/camera/network/engineering{
+	c_tag = "ENG - Belly Solar Maint"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "Gl" = (
 /obj/machinery/seed_storage/xenobotany{
 	dir = 1
@@ -4348,6 +4668,15 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
+"IB" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/random/trash,
+/turf/simulated/floor/airless,
+/area/space)
 "IC" = (
 /obj/structure/sink{
 	pixel_y = 25
@@ -4402,8 +4731,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -4485,6 +4814,14 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/hydroponics)
+"La" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 9;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "Lb" = (
 /obj/structure/bed/chair/sofa/right/blue{
 	dir = 1
@@ -4521,6 +4858,53 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/hydroponics)
+"LP" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/item/weapon/stool/padded{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
+"LR" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"LS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 9;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "LV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4612,6 +4996,12 @@
 /obj/item/weapon/reagent_containers/food/snacks/meat/chicken,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
+"Ni" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "Nx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4629,8 +5019,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
@@ -4720,6 +5110,37 @@
 	},
 /turf/simulated/floor/water/indoors,
 /area/hydroponics/garden)
+"Qc" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"Qi" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "Qj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -4730,6 +5151,16 @@
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/hydroponics)
+"QF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "QH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4767,14 +5198,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
@@ -4784,6 +5215,19 @@
 	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
+"Rw" = (
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Solar - Belly Primary";
+	charge = 3e+006;
+	input_attempt = 1;
+	inputting = 2;
+	name = "Belly Solar Array SMES";
+	input_level = 200000;
+	output_level = 200000
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "Sr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4922,6 +5366,14 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/bar)
+"VB" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "VC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4935,6 +5387,11 @@
 /mob/living/simple_mob/animal/passive/chick,
 /turf/simulated/floor/grass,
 /area/hydroponics)
+"Wi" = (
+/obj/structure/catwalk,
+/obj/random/trash,
+/turf/space,
+/area/space)
 "Wk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -4954,6 +5411,19 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
+"Wq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "Ww" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4969,8 +5439,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4989,8 +5459,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 9;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5159,6 +5629,19 @@
 /obj/structure/sign/botany,
 /turf/simulated/wall,
 /area/hydroponics)
+"YT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "Zi" = (
 /obj/machinery/chem_master/condimaster{
 	name = "DrinkMaster 3000"
@@ -5207,6 +5690,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hydroponics)
+"ZG" = (
+/obj/structure/sign/directions/ladder_up{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/space)
+"ZN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "ZU" = (
 /obj/effect/floor_decal/corner/lightgrey/diagonal{
 	dir = 8
@@ -34604,7 +35101,7 @@ aa
 aa
 aa
 aa
-aa
+bL
 aa
 aa
 aa
@@ -35613,50 +36110,50 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
 aa
 aa
 aa
@@ -35870,48 +36367,48 @@ aa
 aa
 aa
 aa
+AF
+yx
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+Wi
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+yx
+Wi
+eD
+yx
+yx
+aa
+aa
+AF
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
@@ -36127,54 +36624,54 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+bc
+hB
+AF
+qZ
+bc
+hB
+AF
+qZ
+bc
+hB
+AF
+qZ
+bc
+hB
+AF
+qZ
+bc
+hB
+AF
+qZ
+bc
+hB
+AF
+qZ
+bc
+hB
+AF
+qZ
+bc
+hB
+yx
+aa
+aa
+AF
+aa
+aa
+aa
+aa
+AF
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
@@ -36384,54 +36881,54 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+yx
+aa
+aa
+AF
+aa
+aa
+aa
+aa
+AF
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
@@ -36641,48 +37138,48 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+yx
+aa
+aa
+AF
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
@@ -36898,48 +37395,48 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+bf
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+Wi
+aa
+aa
+AF
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
@@ -37155,51 +37652,51 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
+yx
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+eD
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
 PA
 PA
 lm
@@ -37412,48 +37909,48 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+yx
+aa
+yx
+eD
+yx
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
@@ -37669,53 +38166,53 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+yx
+aa
+yx
+oY
+yx
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
 PA
-ag
+QF
 lm
 bX
 uq
@@ -37926,48 +38423,48 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+bf
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+yx
+aa
+Wi
+VB
+cq
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
@@ -38183,55 +38680,55 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+yx
+aa
+yx
+VB
+yx
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
 PA
 sS
 io
-io
+Ni
 io
 Ww
 yw
@@ -38430,60 +38927,60 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+eD
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+AF
+qZ
+LR
+hB
+yx
+yx
+yx
+VB
+yx
+yx
+yx
+kX
+kX
+kX
+kX
 PA
 PA
 ag
@@ -38687,64 +39184,64 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
+eD
+eD
+eD
+eD
+eD
+eD
+eD
+eD
+eD
+eD
+eD
+ZG
+hb
+rd
+rd
+rd
+uC
+rd
+rd
+rd
+uC
+rd
+cM
+rd
+uC
+rd
+rd
+rd
+uC
+rd
+rd
+rd
+uC
+rd
+cM
+rd
+uC
+rd
+rd
+rd
+uC
+rd
+rd
+rd
+rd
+Qc
+IB
+rd
+rd
+hF
+li
+gX
+jz
 PA
 ax
 rX
-IK
+wH
 lB
 lB
 lm
@@ -38944,60 +39441,60 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
+eD
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+eD
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+pG
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+yx
+yx
+yx
+eD
+yx
+yx
+yx
+kX
+yE
+LP
+Rw
 PA
 ir
 lm
@@ -39201,6 +39698,9 @@ aa
 aa
 aa
 aa
+AF
+eD
+AF
 aa
 aa
 aa
@@ -39208,53 +39708,50 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+Wi
+aa
+aa
+AF
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+kX
+sY
+YT
+AH
 PA
 ir
 lB
@@ -39458,6 +39955,9 @@ aa
 aa
 aa
 aa
+AF
+eD
+AF
 aa
 aa
 aa
@@ -39465,53 +39965,50 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+yx
+aa
+aa
+AF
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+kX
+FY
+Wq
+Rw
 PA
 ir
 fM
@@ -39715,6 +40212,9 @@ aa
 aa
 aa
 aa
+AF
+eD
+AF
 aa
 aa
 aa
@@ -39722,56 +40222,53 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+pG
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+yx
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 PA
 PA
 PA
 PA
+vg
 PA
 PA
 ir
-IK
+wH
 lm
 lG
 lW
@@ -39972,6 +40469,9 @@ aa
 aa
 aa
 aa
+AF
+eD
+AF
 aa
 aa
 aa
@@ -39979,52 +40479,49 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+yx
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 PA
 sj
 yN
-Rf
+hM
+DX
 aR
 iL
 AW
@@ -40229,6 +40726,9 @@ aa
 aa
 aa
 aa
+AF
+eD
+AF
 aa
 aa
 aa
@@ -40236,51 +40736,48 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+pG
+hB
+yx
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 PA
 iS
 PA
+cv
 cI
 IK
 lB
@@ -40486,6 +40983,9 @@ aa
 aa
 aa
 aa
+AF
+eD
+AF
 aa
 aa
 aa
@@ -40493,51 +40993,48 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
+yx
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+eD
+AF
+AF
+AF
+AF
 PA
 PA
 PA
+cv
 cI
 PA
 PA
@@ -40743,6 +41240,9 @@ aa
 aa
 aa
 aa
+AF
+eD
+AF
 aa
 aa
 aa
@@ -40750,52 +41250,49 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+yx
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 PA
 lB
-IK
-cI
+cv
+LS
 PA
 aa
 lm
@@ -41000,6 +41497,9 @@ aa
 aa
 aa
 aa
+AF
+eD
+AF
 aa
 aa
 aa
@@ -41007,46 +41507,43 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+AF
+qZ
+Qi
+hB
+yx
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 PA
@@ -41257,6 +41754,9 @@ aa
 aa
 aa
 aa
+AF
+eD
+AF
 aa
 aa
 aa
@@ -41264,51 +41764,48 @@ aa
 aa
 aa
 aa
+AF
+yx
+qZ
+bw
+hB
+AF
+qZ
+bw
+hB
+AF
+qZ
+bw
+hB
+AF
+qZ
+bw
+hB
+AF
+qZ
+bw
+hB
+AF
+qZ
+bw
+hB
+AF
+qZ
+bw
+hB
+AF
+qZ
+bw
+hB
+yx
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 PA
 tE
-IK
+La
 PA
 PA
 aa
@@ -41514,6 +42011,9 @@ aa
 aa
 aa
 aa
+AF
+tt
+AF
 aa
 aa
 aa
@@ -41521,51 +42021,48 @@ aa
 aa
 aa
 aa
+AF
+yx
+yx
+eD
+Wi
+yx
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+Wi
+yx
+eD
+yx
+yx
+yx
+eD
+yx
+yx
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 PA
 Bb
-IK
+ZN
 PA
 aa
 aa
@@ -41771,55 +42268,55 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
 PA
 PA
 PA
@@ -42809,6 +43306,7 @@ aa
 aa
 aa
 aa
+bL
 aa
 aa
 aa
@@ -42842,8 +43340,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+bL
 aa
 aa
 aa

--- a/maps/Arfs/arfs-1-deckone.dmm
+++ b/maps/Arfs/arfs-1-deckone.dmm
@@ -522,9 +522,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "cI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -536,6 +533,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
 "cJ" = (
@@ -1137,6 +1135,15 @@
 /mob/living/simple_mob/animal/sif/sakimm/racoon,
 /turf/simulated/floor/grass,
 /area/hydroponics/garden)
+"gQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "gT" = (
 /obj/structure/bed/chair/sofa/left/black{
 	dir = 1
@@ -3658,6 +3665,12 @@
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "Belly Solar Maintenance"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
 "vh" = (
@@ -4457,12 +4470,6 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
 "DX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -4476,6 +4483,29 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
+"DZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 9;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
@@ -4535,6 +4565,11 @@
 "FY" = (
 /obj/machinery/camera/network/engineering{
 	c_tag = "ENG - Belly Solar Maint"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
@@ -4814,6 +4849,12 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/hydroponics)
+"KY" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/guts/lounge)
 "La" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5223,7 +5264,7 @@
 	inputting = 2;
 	name = "Belly Solar Array SMES";
 	input_level = 200000;
-	output_level = 200000
+	output_level = 100000
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
@@ -5421,6 +5462,12 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
@@ -5640,6 +5687,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
 "Zi" = (
@@ -5701,6 +5751,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/guts/lounge)
@@ -35889,18 +35943,18 @@ aa
 aa
 aa
 aa
+AF
+aa
+aa
+aa
+aa
+AF
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
 aa
 aa
 aa
@@ -36100,16 +36154,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 AF
 AF
 AF
@@ -36154,13 +36198,23 @@ AF
 AF
 AF
 AF
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
+AF
 jr
 Uv
 Rp
@@ -36357,7 +36411,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -36414,7 +36468,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -36614,7 +36668,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -36871,7 +36925,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -37128,7 +37182,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -37385,7 +37439,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -37642,7 +37696,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -37899,7 +37953,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -38156,7 +38210,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -38413,7 +38467,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -38670,7 +38724,7 @@ aa
 aa
 aa
 aa
-aa
+AF
 aa
 aa
 aa
@@ -40778,8 +40832,8 @@ PA
 iS
 PA
 cv
-cI
-IK
+DZ
+KY
 lB
 PA
 lm
@@ -41034,7 +41088,7 @@ AF
 PA
 PA
 PA
-cv
+gQ
 cI
 PA
 PA

--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -27197,6 +27197,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/railing,
+/obj/structure/cable/green{
+	d1 = 32;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "btq" = (
@@ -32776,6 +32781,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_gas)
+"cAy" = (
+/obj/structure/sign/directions/ladder_down,
+/turf/simulated/floor/airless,
+/area/space)
 "cAI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -32812,6 +32821,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_cell_hallway)
+"cCk" = (
+/obj/structure/cable/green{
+	d1 = 32;
+	icon_state = "32-1"
+	},
+/turf/simulated/open,
+/area/maintenance/dormitory)
 "cCN" = (
 /obj/structure/bed/chair/comfy/purp{
 	dir = 1;
@@ -37506,6 +37522,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
+"jtk" = (
+/obj/structure/ladder,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "jvs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -41271,7 +41294,7 @@
 	input_tag = "cooling_in";
 	name = "Engine Cooling Control";
 	output_tag = "cooling_out";
-	sensors = list("engine_sensor" = "Engine Core")
+	sensors = list("engine_sensor"="Engine Core")
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -83826,8 +83849,8 @@ aaa
 amK
 amf
 amK
-aaa
-aaa
+bnS
+aov
 aaa
 aaa
 aaa
@@ -83875,7 +83898,7 @@ bRI
 bRI
 aJZ
 aWs
-aAV
+alt
 aAW
 aOD
 aOD
@@ -84083,8 +84106,8 @@ aaa
 amK
 aCM
 amK
-aaa
-aaa
+cAy
+aov
 aaa
 aaa
 aaa
@@ -84132,7 +84155,7 @@ aKb
 aKb
 aMG
 btp
-alt
+cCk
 aAW
 aaa
 aaa
@@ -84340,8 +84363,8 @@ aaa
 amK
 amg
 amK
-aaa
-aaa
+jtk
+aov
 aaa
 aaa
 aaa

--- a/maps/Arfs/arfs-2-decktwo.dmm
+++ b/maps/Arfs/arfs-2-decktwo.dmm
@@ -22811,7 +22811,9 @@
 	charge = 3e+006;
 	input_attempt = 1;
 	inputting = 2;
-	name = "Port Solar Array SMES"
+	name = "Port Solar Array SMES";
+	output_level = 100000;
+	input_level = 200000
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -27339,7 +27341,9 @@
 	charge = 3e+006;
 	input_attempt = 1;
 	inputting = 2;
-	name = "Starboard Solar Array SMES"
+	name = "Starboard Solar Array SMES";
+	input_level = 200000;
+	output_level = 100000
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
@@ -32719,7 +32723,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/research)
 "cvF" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -36036,9 +36040,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
-"htr" = (
-/turf/simulated/wall,
-/area/space)
 "huz" = (
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 8
@@ -44274,7 +44275,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/research)
 "sNS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -88069,7 +88070,7 @@ bez
 bsB
 bth
 bez
-htr
+bez
 aov
 aov
 sWm

--- a/maps/Arfs/arfs_defines.dm
+++ b/maps/Arfs/arfs_defines.dm
@@ -21,8 +21,8 @@
 
 	zlevel_datum_type = /datum/map_z_level/arfs
 
-	lobby_icon = 'content_arfs/icons/misc/arfs_dallus_new.dmi'
-	lobby_screens = list("arfs_dallus_new")
+	lobby_icon = 'content_arfs/icons/misc/arfs_dallus.dmi'
+	lobby_screens = list("arfs_dallus_new_anim")
 
 	station_name  = "ARFS Dallus"
 	station_short = "Dallus"


### PR DESCRIPTION
Stops the lights from going out with more auto solars. The engine will still be needed for powering a shield generator or anything like that though.
Also, I moved the lobby screen to another file to see if it still comes up as a black screen on the server. Can't recreate the problem on my local so there's no telling if this will work. Idk anymore.